### PR TITLE
deserial. structure/table with value "null"

### DIFF
--- a/src/z_ui2_json.clas.abap
+++ b/src/z_ui2_json.clas.abap
@@ -2139,6 +2139,8 @@ ENDMETHOD.
                   ENDIF.
                 ELSEIF type_descr->kind EQ type_descr->kind_elem.
                   eat_bool data.
+                ELSEIF type_descr->kind EQ type_descr->kind_struct OR type_descr->kind EQ type_descr->kind_table.
+                  eat_null data.
                 ELSE.
                   eat_bool sdummy.
                   throw_error.

--- a/src/z_ui2_json.clas.locals_imp.abap
+++ b/src/z_ui2_json.clas.locals_imp.abap
@@ -353,3 +353,14 @@ DEFINE eat_char.
     throw_error.
   ENDIF.
 END-OF-DEFINITION.
+
+DEFINE eat_null.
+  mark   = offset.
+  while_offset_cs `nul`.
+  match = offset - mark.
+  IF json+mark(match) EQ `null`  ##NO_TEXT.
+    CLEAR &1.
+  ELSE.
+    throw_error.
+  ENDIF.
+END-OF-DEFINITION.

--- a/src/z_ui2_json.clas.testclasses.abap
+++ b/src/z_ui2_json.clas.testclasses.abap
@@ -263,6 +263,10 @@ INHERITING FROM z_ui2_json.
     METHODS: serialize_formatted FOR TESTING.
     METHODS: serialize_cycle_reference FOR TESTING.
 
+    METHODS: deserialize_table_null FOR TESTING.
+    METHODS: deserialize_structure_null FOR TESTING.
+    METHODS: deserialize_string_null FOR TESTING.
+
 ENDCLASS.       "abap_unit_testclass
 * ----------------------------------------------------------------------
 CLASS abap_unit_testclass IMPLEMENTATION.
@@ -2866,6 +2870,100 @@ CLASS abap_unit_testclass IMPLEMENTATION.
                           format_output    = abap_true
                           assoc_arrays     = abap_true
                           assoc_arrays_opt = abap_true ).
+  ENDMETHOD.
+
+  METHOD deserialize_table_null.
+
+    TYPES: BEGIN OF ty_test,
+             tab1    TYPE STANDARD TABLE OF string WITH EMPTY KEY,
+             BEGIN OF struc1,
+               field1 TYPE string,
+             END OF struc1,
+             string1 TYPE string,
+           END OF ty_test.
+
+    DATA s_test2 TYPE ty_test.
+
+    deserialize(
+      EXPORTING
+        json             = '{"tab1":null,"struc1":{"field1":"hugo"},"string1":"u__u"}'
+      CHANGING
+        data             = s_test2
+    ).
+
+    cl_abap_unit_assert=>assert_initial(
+       act = s_test2-tab1 ).
+
+    cl_abap_unit_assert=>assert_equals(
+           exp = 'hugo'
+           act = s_test2-struc1-field1 ).
+
+    cl_abap_unit_assert=>assert_equals(
+           exp = 'u__u'
+           act = s_test2-string1 ).
+
+  ENDMETHOD.
+
+  METHOD deserialize_structure_null.
+
+    TYPES: BEGIN OF ty_test,
+             tab1    TYPE STANDARD TABLE OF string WITH EMPTY KEY,
+             BEGIN OF struc1,
+               field1 TYPE string,
+             END OF struc1,
+             string1 TYPE string,
+           END OF ty_test.
+
+    DATA s_test2 TYPE ty_test.
+
+    deserialize(
+      EXPORTING
+        json             = '{"tab1":["hugo"],"struc1":null,"string1":"u__u"}'
+      CHANGING
+        data             = s_test2
+    ).
+
+    cl_abap_unit_assert=>assert_equals(
+           exp = `hugo`
+           act = s_test2-tab1[ 1 ] ).
+
+    cl_abap_unit_assert=>assert_initial(
+       act = s_test2-struc1 ).
+
+    cl_abap_unit_assert=>assert_equals(
+           exp = 'u__u'
+           act = s_test2-string1 ).
+  ENDMETHOD.
+
+  METHOD deserialize_string_null.
+
+    TYPES: BEGIN OF ty_test2,
+             tab1    TYPE STANDARD TABLE OF string WITH EMPTY KEY,
+             BEGIN OF struc1,
+               field1 TYPE string,
+             END OF struc1,
+             string1 TYPE string,
+           END OF ty_test2.
+
+    DATA s_test2 TYPE ty_test2.
+
+    deserialize(
+      EXPORTING
+        json             = '{"tab1":["hugo"],"struc1":{"field1":"hugo"},"string1":null}'
+      CHANGING
+        data             = s_test2
+    ).
+
+    cl_abap_unit_assert=>assert_equals(
+          exp = `hugo`
+          act = s_test2-tab1[ 1 ] ).
+
+    cl_abap_unit_assert=>assert_equals(
+          exp = 'hugo'
+          act = s_test2-struc1-field1 ).
+
+    cl_abap_unit_assert=>assert_initial(
+           act = s_test2-string1 ).
   ENDMETHOD.
 
 ENDCLASS.       "abap_unit_testclass

--- a/src/z_ui2_json.clas.testclasses.abap
+++ b/src/z_ui2_json.clas.testclasses.abap
@@ -263,9 +263,12 @@ INHERITING FROM z_ui2_json.
     METHODS: serialize_formatted FOR TESTING.
     METHODS: serialize_cycle_reference FOR TESTING.
 
-    METHODS: deserialize_table_null FOR TESTING.
-    METHODS: deserialize_structure_null FOR TESTING.
-    METHODS: deserialize_string_null FOR TESTING.
+    "! deserialize a null value for a table field in strict mode
+    METHODS deserialize_strict_table_null FOR TESTING.
+    "! deserialize a null value for a structure field in strict mode
+    METHODS deserialize_strict_struct_null FOR TESTING.
+    "! deserialize a null value for a string field in strict mode
+    METHODS deserialize_strict_string_null FOR TESTING.
 
 ENDCLASS.       "abap_unit_testclass
 * ----------------------------------------------------------------------
@@ -2872,7 +2875,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
                           assoc_arrays_opt = abap_true ).
   ENDMETHOD.
 
-  METHOD deserialize_table_null.
+  METHOD deserialize_strict_table_null.
 
     TYPES: BEGIN OF ty_test,
              tab1    TYPE STANDARD TABLE OF string WITH EMPTY KEY,
@@ -2884,7 +2887,13 @@ CLASS abap_unit_testclass IMPLEMENTATION.
 
     DATA s_test2 TYPE ty_test.
 
-    deserialize(
+    DATA lo_json TYPE t_json.
+    CREATE OBJECT lo_json
+      EXPORTING
+        strict_mode = abap_true
+        pretty_name = pretty_mode-camel_case.
+
+    lo_json->deserialize_int(
       EXPORTING
         json             = '{"tab1":null,"struc1":{"field1":"hugo"},"string1":"u__u"}'
       CHANGING
@@ -2904,7 +2913,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD deserialize_structure_null.
+  METHOD deserialize_strict_struct_null.
 
     TYPES: BEGIN OF ty_test,
              tab1    TYPE STANDARD TABLE OF string WITH EMPTY KEY,
@@ -2916,7 +2925,13 @@ CLASS abap_unit_testclass IMPLEMENTATION.
 
     DATA s_test2 TYPE ty_test.
 
-    deserialize(
+    DATA lo_json TYPE t_json.
+    CREATE OBJECT lo_json
+      EXPORTING
+        strict_mode = abap_true
+        pretty_name = pretty_mode-camel_case.
+
+    lo_json->deserialize_int(
       EXPORTING
         json             = '{"tab1":["hugo"],"struc1":null,"string1":"u__u"}'
       CHANGING
@@ -2935,7 +2950,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
            act = s_test2-string1 ).
   ENDMETHOD.
 
-  METHOD deserialize_string_null.
+  METHOD deserialize_strict_string_null.
 
     TYPES: BEGIN OF ty_test2,
              tab1    TYPE STANDARD TABLE OF string WITH EMPTY KEY,
@@ -2947,7 +2962,13 @@ CLASS abap_unit_testclass IMPLEMENTATION.
 
     DATA s_test2 TYPE ty_test2.
 
-    deserialize(
+    DATA lo_json TYPE t_json.
+    CREATE OBJECT lo_json
+      EXPORTING
+        strict_mode = abap_true
+        pretty_name = pretty_mode-camel_case.
+
+    lo_json->deserialize_int(
       EXPORTING
         json             = '{"tab1":["hugo"],"struc1":{"field1":"hugo"},"string1":null}'
       CHANGING


### PR DESCRIPTION
In the deserializer, the value "null" is not accepted for structure and table types and an exception is raised.

In the changed code of my pull request, the value "null" is handled like an initial structure ("{}") or table ("[]").

In my company we need this behavior, because some Java applications serialize empty tables/arrays to the value "null" (e.g. in Swagger "nullable: true").