### PR TITLE
at deser. error: add path of invalid field to msg

### DIFF
--- a/src/z_ui2_json.clas.abap
+++ b/src/z_ui2_json.clas.abap
@@ -1659,7 +1659,10 @@ ENDMETHOD.
           data_ref   TYPE REF TO data,
           object_ref TYPE REF TO object,
           fields     LIKE field_cache,
-          name_json  TYPE string.
+          name_json  TYPE string,
+          lo_move_cast_error TYPE REF TO cx_sy_move_cast_error,
+          source_typename type string,
+          target_typename type string.
 
     FIELD-SYMBOLS: <value>       TYPE any,
                    <field_cache> LIKE LINE OF field_cache.
@@ -1734,17 +1737,26 @@ ENDMETHOD.
             EXIT.
           ENDIF.
 
-        CATCH cx_sy_move_cast_error INTO DATA(lx_move).
+        CATCH cx_sy_move_cast_error INTO lo_move_cast_error.
+            IF lo_move_cast_error->source_typename IS NOT INITIAL AND lo_move_cast_error->source_typename(1) <> `[`.
+              source_typename = name_json && |.| && lo_move_cast_error->source_typename.
+            ELSE.
+              source_typename = name_json && lo_move_cast_error->source_typename.
+            ENDIF.
+
+            IF lo_move_cast_error->target_typename IS NOT INITIAL.
+              target_typename = lo_move_cast_error->target_typename.
+            ELSEIF <field_cache> IS ASSIGNED.
+              target_typename = |{ <field_cache>-elem_type->absolute_name }|.
+            ELSE.
+              target_typename = `?`.
+            ENDIF.
+
             RAISE EXCEPTION TYPE cx_sy_move_cast_error
               EXPORTING
-                previous        = lx_move
-                source_typename = name_json && COND #( WHEN lx_move->source_typename IS NOT INITIAL AND lx_move->source_typename(1) <> `[` THEN |.| ) && lx_move->source_typename
-                target_typename = COND #( WHEN lx_move->target_typename IS NOT INITIAL
-                                              THEN lx_move->target_typename
-                                            WHEN <field_cache> IS ASSIGNED
-                                              THEN |{ <field_cache>-elem_type->absolute_name }|
-                                            ELSE `?`
-                                          ).
+                previous        = lo_move_cast_error
+                source_typename = source_typename
+                target_typename = target_typename.
       ENDTRY.
 
     ENDWHILE.
@@ -1767,27 +1779,31 @@ ENDMETHOD.
       lc_edm_time_regexp      TYPE string VALUE `^-?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)(?:\.(\d+))?S)?)?\s*$`. "#EC NOTEXT
 
 
-    DATA: mark         LIKE offset,
-          match        LIKE offset,
-          sdummy       TYPE string,                         "#EC NEEDED
-          rdummy       TYPE REF TO data,                    "#EC NEEDED
-          pos          LIKE offset,
-          line         TYPE REF TO data,
-          key_ref      TYPE REF TO data,
-          data_ref     TYPE REF TO data,
-          key_name     TYPE string,
-          key_value    TYPE string,
-          lt_fields    LIKE field_cache,
-          ls_symbols   TYPE t_s_struct_cache_res,
-          lv_ticks     TYPE string,
-          lv_offset    TYPE string,
-          lv_convexit  LIKE convexit,
-          lo_exp       TYPE REF TO cx_root,
-          elem_descr   TYPE REF TO cl_abap_elemdescr,
-          table_descr  TYPE REF TO cl_abap_tabledescr,
-          struct_descr TYPE REF TO cl_abap_structdescr,
-          ref_descr    TYPE REF TO cl_abap_refdescr,
-          data_descr   TYPE REF TO cl_abap_datadescr.
+    DATA: mark               LIKE offset,
+          match              LIKE offset,
+          sdummy             TYPE string,                   "#EC NEEDED
+          rdummy             TYPE REF TO data,              "#EC NEEDED
+          pos                LIKE offset,
+          line               TYPE REF TO data,
+          key_ref            TYPE REF TO data,
+          data_ref           TYPE REF TO data,
+          key_name           TYPE string,
+          key_value          TYPE string,
+          lt_fields          LIKE field_cache,
+          ls_symbols         TYPE t_s_struct_cache_res,
+          lv_ticks           TYPE string,
+          lv_offset          TYPE string,
+          lv_convexit        LIKE convexit,
+          lo_exp             TYPE REF TO cx_root,
+          elem_descr         TYPE REF TO cl_abap_elemdescr,
+          table_descr        TYPE REF TO cl_abap_tabledescr,
+          struct_descr       TYPE REF TO cl_abap_structdescr,
+          ref_descr          TYPE REF TO cl_abap_refdescr,
+          data_descr         TYPE REF TO cl_abap_datadescr,
+          array_index        TYPE i,
+          lo_move_cast_error TYPE REF TO cx_sy_move_cast_error,
+          source_typename    TYPE string,
+          target_typename    TYPE string.
 
     FIELD-SYMBOLS: <line>      TYPE any,
                    <value>     TYPE any,
@@ -1944,7 +1960,7 @@ ENDMETHOD.
                     CREATE DATA line LIKE LINE OF <table>.
                     ASSIGN line->* TO <line>.
                     lt_fields = get_fields( type_descr = data_descr data = line ).
-                    DATA(array_index) = 0.
+                    array_index = 0.
                     WHILE offset < length AND json+offset(1) NE ']'.
                       array_index = sy-index.
                       CLEAR <line>.
@@ -2182,34 +2198,55 @@ ENDMETHOD.
               ENDIF.
           ENDCASE.
         ENDIF.
-      CATCH cx_sy_move_cast_error INTO DATA(lo_move_exp).
+      CATCH cx_sy_move_cast_error INTO lo_move_cast_error.
         " + CX_SY_CONVERSION_NOT_SUPPORTED > 7.54
         CLEAR data.
         IF mv_strict_mode EQ abap_true.
 
+          IF key_value IS NOT INITIAL.
+            IF lo_move_cast_error->source_typename IS NOT INITIAL AND lo_move_cast_error->source_typename(1) <> `[`.
+              source_typename = key_value && |.| && lo_move_cast_error->source_typename.
+            ELSE.
+              source_typename = key_value && lo_move_cast_error->source_typename.
+            ENDIF.
+          ELSEIF array_index > 0.
+            IF lo_move_cast_error->source_typename IS NOT INITIAL AND lo_move_cast_error->source_typename(1) <> `[`.
+              source_typename = |[{ array_index }]| && |.| && lo_move_cast_error->source_typename.
+            ELSE.
+              source_typename = |[{ array_index }]| && lo_move_cast_error->source_typename.
+            ENDIF.
+          ELSE.
+            source_typename = lo_move_cast_error->source_typename.
+          ENDIF.
+          IF lo_move_cast_error->target_typename IS NOT INITIAL.
+            target_typename = lo_move_cast_error->target_typename.
+          ELSEIF type_descr IS BOUND.
+            CASE type_descr->kind.
+              WHEN cl_abap_typedescr=>kind_table.
+                target_typename = `table`.
+              WHEN cl_abap_typedescr=>kind_struct.
+                target_typename = `structure`.
+              WHEN cl_abap_typedescr=>kind_class.
+                target_typename = `class`.
+              WHEN cl_abap_typedescr=>kind_intf.
+                target_typename = `interface`.
+              WHEN cl_abap_typedescr=>kind_ref.
+                target_typename = `reference`.
+              WHEN cl_abap_typedescr=>kind_elem.
+                elem_descr ?= type_descr.
+                target_typename = elem_descr->absolute_name.
+              WHEN OTHERS.
+                target_typename = `?`.
+            ENDCASE.
+          ELSE.
+            target_typename = `?`.
+          ENDIF.
+
           RAISE EXCEPTION TYPE cx_sy_move_cast_error
             EXPORTING
-              previous        = lo_move_exp
-              source_typename = COND #( WHEN key_value IS NOT INITIAL
-                                          THEN key_value && COND #( WHEN lo_move_exp->source_typename IS NOT INITIAL AND lo_move_exp->source_typename(1) <> `[` THEN |.| )
-                                         WHEN array_index > 0
-                                          THEN |[{ array_index }]| && COND #( WHEN lo_move_exp->source_typename IS NOT INITIAL AND lo_move_exp->source_typename(1) <> `[` THEN |.| )
-                                      ) && lo_move_exp->source_typename
-              target_typename = COND #( WHEN lo_move_exp->target_typename IS NOT INITIAL
-                                          THEN lo_move_exp->target_typename
-                                        WHEN type_descr IS BOUND
-                                          THEN SWITCH #( type_descr->kind
-                                              WHEN cl_abap_typedescr=>kind_table  THEN `table`
-                                              WHEN cl_abap_typedescr=>kind_struct THEN `structure`
-                                              WHEN cl_abap_typedescr=>kind_class  THEN `class`
-                                              WHEN cl_abap_typedescr=>kind_intf   THEN `interface`
-                                              WHEN cl_abap_typedescr=>kind_ref    THEN `reference`
-                                              WHEN cl_abap_typedescr=>kind_elem   THEN
-                                                  |{ CAST cl_abap_elemdescr( type_descr )->absolute_name }|
-                                              ELSE `?`
-                                               )
-                                          ELSE `?`
-                                      ).
+              previous        = lo_move_cast_error
+              source_typename = source_typename
+              target_typename = target_typename.
 
         ENDIF.
       CATCH cx_sy_conversion_no_number cx_sy_conversion_overflow INTO lo_exp.

--- a/src/z_ui2_json.clas.testclasses.abap
+++ b/src/z_ui2_json.clas.testclasses.abap
@@ -3025,19 +3025,22 @@ CLASS abap_unit_testclass IMPLEMENTATION.
         tab2    TYPE STANDARD TABLE OF ty_test WITH EMPTY KEY,
       END OF ty_test2.
 
-    DATA s_test2 TYPE ty_test2.
+    DATA: s_test2    TYPE ty_test2,
+          serializer TYPE REF TO z_ui2_json,
+          lx_move    TYPE REF TO cx_sy_move_cast_error
+          .
 
-    DATA(serializer) = NEW z_ui2_json(
-            compress         = abap_true
-            pretty_name      = z_ui2_json=>pretty_mode-camel_case
-            assoc_arrays     = abap_true
-            assoc_arrays_opt = abap_true
-            ts_as_iso8601    = abap_false
-            expand_includes  = abap_true
-            strict_mode      = abap_true " raise sometimes an exception in error case
-            numc_as_string   = abap_false
-            conversion_exits = abap_false
-        ).
+    CREATE OBJECT serializer
+      EXPORTING
+        compress         = abap_true
+        pretty_name      = z_ui2_json=>pretty_mode-camel_case
+        assoc_arrays     = abap_true
+        assoc_arrays_opt = abap_true
+        ts_as_iso8601    = abap_false
+        expand_includes  = abap_true
+        strict_mode      = abap_true " raise sometimes an exception in error case
+        numc_as_string   = abap_false
+        conversion_exits = abap_false.
 
     TRY.
         serializer->deserialize_int(
@@ -3047,7 +3050,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
             data             = s_test2
         ).
         cl_abap_unit_assert=>fail( ).
-      CATCH cx_sy_move_cast_error INTO DATA(lx_move).
+      CATCH cx_sy_move_cast_error INTO lx_move.
         cl_abap_unit_assert=>assert_equals(
             exp = `$.tab1`
             act = lx_move->source_typename
@@ -3119,9 +3122,13 @@ CLASS abap_unit_testclass IMPLEMENTATION.
              string1 TYPE string,
            END OF ty_test2.
 
-    DATA s_test2 TYPE ty_test2.
+    DATA: s_test2    TYPE ty_test2,
+          serializer TYPE REF TO z_ui2_json,
+          lx_move    TYPE REF TO cx_sy_move_cast_error
+          .
 
-    DATA(serializer) = NEW z_ui2_json(
+    CREATE OBJECT serializer
+      EXPORTING
             compress         = abap_true
             pretty_name      = z_ui2_json=>pretty_mode-camel_case
             assoc_arrays     = abap_true
@@ -3131,7 +3138,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
             strict_mode      = abap_true " raise sometimes an exception in error case
             numc_as_string   = abap_false
             conversion_exits = abap_false
-        ).
+        .
 
     TRY.
         serializer->deserialize_int(
@@ -3141,7 +3148,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
             data             = s_test2
         ).
         cl_abap_unit_assert=>fail( ).
-      CATCH cx_sy_move_cast_error INTO DATA(lx_move).
+      CATCH cx_sy_move_cast_error INTO lx_move.
         cl_abap_unit_assert=>assert_equals(
             exp = `$.struc1`
             act = lx_move->source_typename
@@ -3182,9 +3189,13 @@ CLASS abap_unit_testclass IMPLEMENTATION.
              string1 TYPE string,
            END OF ty_test2.
 
-    DATA s_test2 TYPE ty_test2.
+    DATA: s_test2    TYPE ty_test2,
+          serializer TYPE REF TO z_ui2_json,
+          lx_move    TYPE REF TO cx_sy_move_cast_error
+          .
 
-    DATA(serializer) = NEW z_ui2_json(
+    CREATE OBJECT serializer
+      EXPORTING
             compress         = abap_true
             pretty_name      = z_ui2_json=>pretty_mode-camel_case
             assoc_arrays     = abap_true
@@ -3194,7 +3205,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
             strict_mode      = abap_true " raise sometimes an exception in error case
             numc_as_string   = abap_false
             conversion_exits = abap_false
-        ).
+        .
 
     TRY.
         serializer->deserialize_int(
@@ -3204,7 +3215,7 @@ CLASS abap_unit_testclass IMPLEMENTATION.
             data             = s_test2
         ).
         cl_abap_unit_assert=>fail( ).
-      CATCH cx_sy_move_cast_error INTO DATA(lx_move).
+      CATCH cx_sy_move_cast_error INTO lx_move.
         cl_abap_unit_assert=>assert_equals(
             exp = `$.struc1.field1`
             act = lx_move->source_typename

--- a/src/z_ui2_json.clas.testclasses.abap
+++ b/src/z_ui2_json.clas.testclasses.abap
@@ -283,6 +283,16 @@ INHERITING FROM z_ui2_json.
     "! deserialize a null value for a string field in strict mode
     METHODS deserialize_strict_string_null FOR TESTING.
 
+    "! test error message with path to the field with an invalid value<br/>
+    "! try to deserialize a JSON string with an invalid value for a table type
+    METHODS deser_table_invalid_value FOR TESTING.
+    "! test error message with path to the field with an invalid value<br/>
+    "! try to deserialize a JSON string with an invalid value for a structure type
+    METHODS deser_structure_invalid_value FOR TESTING.
+    "! test error message with path to the field with an invalid value<br/>
+    "! try to deserialize a JSON string with an invalid value for a string type
+    METHODS deser_field_invalid_value FOR TESTING.
+
 ENDCLASS.       "abap_unit_testclass
 * ----------------------------------------------------------------------
 CLASS abap_unit_testclass IMPLEMENTATION.
@@ -2999,5 +3009,213 @@ CLASS abap_unit_testclass IMPLEMENTATION.
     cl_abap_unit_assert=>assert_initial( act = s_test2-string1 ).
 
   ENDMETHOD.                    "deserialize_strict_string_null
+
+  METHOD deser_table_invalid_value.
+
+    TYPES:
+      BEGIN OF ty_test,
+        int_p2  TYPE i,
+      END OF ty_test,
+      BEGIN OF ty_test2,
+        tab1    TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+        BEGIN OF struc1,
+          field1 TYPE string,
+        END OF struc1,
+        string1 TYPE string,
+        tab2    TYPE STANDARD TABLE OF ty_test WITH EMPTY KEY,
+      END OF ty_test2.
+
+    DATA s_test2 TYPE ty_test2.
+
+    DATA(serializer) = NEW z_ui2_json(
+            compress         = abap_true
+            pretty_name      = z_ui2_json=>pretty_mode-camel_case
+            assoc_arrays     = abap_true
+            assoc_arrays_opt = abap_true
+            ts_as_iso8601    = abap_false
+            expand_includes  = abap_true
+            strict_mode      = abap_true " raise sometimes an exception in error case
+            numc_as_string   = abap_false
+            conversion_exits = abap_false
+        ).
+
+    TRY.
+        serializer->deserialize_int(
+          EXPORTING
+            json             = '{"tab1":true,"string1":"u__u"}'
+          CHANGING
+            data             = s_test2
+        ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_sy_move_cast_error INTO DATA(lx_move).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `$.tab1`
+            act = lx_move->source_typename
+             ).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `table`
+            act = lx_move->target_typename
+             ).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `Source type $.tab1 is not compatible, for the purposes of assignment, with target type table`
+            act = lx_move->get_text( )
+             ).
+    ENDTRY.
+
+    TRY.
+        serializer->deserialize_int(
+          EXPORTING
+            json             = '{"tab1":"hugo","string1":"u__u"}'
+          CHANGING
+            data             = s_test2
+        ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_sy_move_cast_error INTO lx_move.
+        cl_abap_unit_assert=>assert_equals(
+            exp = `$.tab1`
+            act = lx_move->source_typename
+             ).
+    ENDTRY.
+
+    TRY.
+        serializer->deserialize_int(
+          EXPORTING
+            json             = '{"tab1":["hugo",?]}'
+          CHANGING
+            data             = s_test2
+        ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_sy_move_cast_error INTO lx_move.
+        cl_abap_unit_assert=>assert_equals(
+            exp = `$.tab1[2]`
+            act = lx_move->source_typename
+             ).
+    ENDTRY.
+
+    TRY.
+        serializer->deserialize_int(
+          EXPORTING
+            json             = '{"tab2":[{"intP2":1 },{"intP2":"illegal int"}]}'
+          CHANGING
+            data             = s_test2
+        ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_sy_move_cast_error INTO lx_move.
+        cl_abap_unit_assert=>assert_equals(
+            exp = `$.tab2[2].intP2`
+            act = lx_move->source_typename
+             ).
+    ENDTRY.
+
+  ENDMETHOD.
+
+  METHOD deser_structure_invalid_value.
+
+    TYPES: BEGIN OF ty_test2,
+             tab1    TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+             BEGIN OF struc1,
+               field1 TYPE string,
+             END OF struc1,
+             string1 TYPE string,
+           END OF ty_test2.
+
+    DATA s_test2 TYPE ty_test2.
+
+    DATA(serializer) = NEW z_ui2_json(
+            compress         = abap_true
+            pretty_name      = z_ui2_json=>pretty_mode-camel_case
+            assoc_arrays     = abap_true
+            assoc_arrays_opt = abap_true
+            ts_as_iso8601    = abap_false
+            expand_includes  = abap_true
+            strict_mode      = abap_true " raise sometimes an exception in error case
+            numc_as_string   = abap_false
+            conversion_exits = abap_false
+        ).
+
+    TRY.
+        serializer->deserialize_int(
+          EXPORTING
+            json             = '{"struc1":true,"string1":"u__u"}'
+          CHANGING
+            data             = s_test2
+        ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_sy_move_cast_error INTO DATA(lx_move).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `$.struc1`
+            act = lx_move->source_typename
+             ).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `structure`
+            act = lx_move->target_typename
+             ).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `Source type $.struc1 is not compatible, for the purposes of assignment, with target type structure`
+            act = lx_move->get_text( )
+             ).
+    ENDTRY.
+
+    TRY.
+        serializer->deserialize_int(
+          EXPORTING
+            json             = '{"struc1":"hugo","string1":"u__u"}'
+          CHANGING
+            data             = s_test2
+        ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_sy_move_cast_error INTO lx_move.
+        cl_abap_unit_assert=>assert_equals(
+            exp = `$.struc1`
+            act = lx_move->source_typename
+             ).
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD deser_field_invalid_value.
+
+    TYPES: BEGIN OF ty_test2,
+             tab1    TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
+             BEGIN OF struc1,
+               field1 TYPE string,
+             END OF struc1,
+             string1 TYPE string,
+           END OF ty_test2.
+
+    DATA s_test2 TYPE ty_test2.
+
+    DATA(serializer) = NEW z_ui2_json(
+            compress         = abap_true
+            pretty_name      = z_ui2_json=>pretty_mode-camel_case
+            assoc_arrays     = abap_true
+            assoc_arrays_opt = abap_true
+            ts_as_iso8601    = abap_false
+            expand_includes  = abap_true
+            strict_mode      = abap_true " raise sometimes an exception in error case
+            numc_as_string   = abap_false
+            conversion_exits = abap_false
+        ).
+
+    TRY.
+        serializer->deserialize_int(
+          EXPORTING
+            json             = '{"struc1":{"field1":?}}'
+          CHANGING
+            data             = s_test2
+        ).
+        cl_abap_unit_assert=>fail( ).
+      CATCH cx_sy_move_cast_error INTO DATA(lx_move).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `$.struc1.field1`
+            act = lx_move->source_typename
+             ).
+        cl_abap_unit_assert=>assert_equals(
+            exp = `\TYPE=STRING`
+            act = lx_move->target_typename
+             ).
+    ENDTRY.
+
+
+  ENDMETHOD.
 
 ENDCLASS.       "abap_unit_testclass


### PR DESCRIPTION
Hi Alexey,

My modification is for deserialization in strict mode.
In error case, the path to the field with an illegal value is included in the error message. Therefore, the path (in JSON Path format) is stored in the variable cx_sy_move_cast_error->source_typename. The exception cx_sy_move_cast_error was also used before, only the variable source_typename was not filled.

I have another modification in my pipeline for identifying date-times also on domain level. Therefore I will create another pull request after this one is closed.

BR,
Lukas