### PR TITLE
chore: add version constant to `.abapgit.xml`

### DIFF
--- a/.abapgit.xml
+++ b/.abapgit.xml
@@ -2,9 +2,11 @@
 <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
  <asx:values>
   <DATA>
+   <NAME>sap-ui2-json</NAME>
    <MASTER_LANGUAGE>E</MASTER_LANGUAGE>
    <STARTING_FOLDER>/src/</STARTING_FOLDER>
    <FOLDER_LOGIC>PREFIX</FOLDER_LOGIC>
+   <VERSION_CONSTANT>Z_UI2_JSON=&gt;VERSION</VERSION_CONSTANT>
   </DATA>
  </asx:values>
 </asx:abap>


### PR DESCRIPTION
Add version constant (will auto-update). You can use it, for example, to [create a badge](https://tools.abappm.com/):

<img width="601" height="268" alt="image" src="https://github.com/user-attachments/assets/39b06ba0-2250-4d64-8c34-e7f86ec8e010" />


We should also add the minimum SAP Basis release to `.abapgit.xml`. What is it?

<img width="602" height="192" alt="image" src="https://github.com/user-attachments/assets/45216dd0-51eb-4dbd-9a30-05a37346297b" />
