### PR TITLE
Add Z_UI2_YAML: self-contained YAML 1.2 config reader/writer

### DIFF
--- a/docs/feature-requests-yaml.md
+++ b/docs/feature-requests-yaml.md
@@ -1,0 +1,24 @@
+# Z_UI2_YAML Feature Requests
+
+This is the **own backlog for Z_UI2_YAML**, separate from the JSON class backlog
+(`docs/feature-requests.md`). Do not mix YAML items into the JSON list.
+
+---
+
+## Known v1 Deferrals (future work)
+
+| # | Item | Notes |
+|---|------|-------|
+| 1 | **pretty_name inverse on DESERIALIZE** | camelCase/PascalCase key → ABAP component name mapping not applied during deserialization; only case-insensitive uppercase match is used. |
+| 2 | **Anchor emission on write** | `&anchor` / `*alias` in serialized output. Anchors are fully supported on read (Task 7). |
+| 3 | **Block-header anchors on read** | `key: &a |` — anchor on a line that also carries a block-scalar indicator. Deferred from Task 7. |
+| 4 | **Multi-document streams** | `---` separators produce only the first document; subsequent documents are ignored. |
+| 5 | **Tags** | `!!str`, `!!int`, `!<uri>` tags are silently ignored. |
+| 6 | **Explicit block-scalar indent indicator** | `|2`, `>4` — indent column from indicator digit. Auto-detection from body content is used instead. |
+| 7 | **Reconsider default key case** | `pretty_mode-none` (default) preserves ABAP UPPERCASE names. Many YAML users expect lowercase. Consider making `low_case` the default in a future major version, or documenting the pattern more prominently. |
+
+---
+
+## Open Requests
+
+*(none yet)*

--- a/docs/feature-requests-yaml.md
+++ b/docs/feature-requests-yaml.md
@@ -5,20 +5,31 @@ This is the **own backlog for Z_UI2_YAML**, separate from the JSON class backlog
 
 ---
 
-## Known v1 Deferrals (future work)
+## Known v1 Deferrals — Status Update (2026-07-31)
 
-| # | Item | Notes |
-|---|------|-------|
-| 1 | **pretty_name inverse on DESERIALIZE** | camelCase/PascalCase key → ABAP component name mapping not applied during deserialization; only case-insensitive uppercase match is used. |
-| 2 | **Anchor emission on write** | `&anchor` / `*alias` in serialized output. Anchors are fully supported on read (Task 7). |
-| 3 | **Block-header anchors on read** | `key: &a |` — anchor on a line that also carries a block-scalar indicator. Deferred from Task 7. |
-| 4 | **Multi-document streams** | `---` separators produce only the first document; subsequent documents are ignored. |
-| 5 | **Tags** | `!!str`, `!!int`, `!<uri>` tags are silently ignored. |
-| 6 | **Explicit block-scalar indent indicator** | `|2`, `>4` — indent column from indicator digit. Auto-detection from body content is used instead. |
-| 7 | **Reconsider default key case** | `pretty_mode-none` (default) preserves ABAP UPPERCASE names. Many YAML users expect lowercase. Consider making `low_case` the default in a future major version, or documenting the pattern more prominently. |
+Items #1, #3, #4 have been completed and shipped:
+- **#1 camelCase/PascalCase inverse on DESERIALIZE** — now supported with `pretty_name = pretty_mode-camel_case` / `pascal_case`
+- **#3 Block-header anchors on read** — now supported (e.g. `key: &a |`)
+- **#4 Multi-document streams** — new methods `GENERATE_ALL` and `DESERIALIZE_ALL` now process all documents
+
+Remaining items #2, #5, #6, #7 are documented in the "Declined" section below.
+
+---
+
+## Declined (see CLAUDE.md API Design Decisions)
+
+The following items have been evaluated and formally declined:
+
+| Item | Reason | Decision Source |
+|------|--------|-----------------|
+| **Anchor emission on write** | Config producers emit expanded YAML for human readability; anchors need cycle detection + dedup heuristics. Read-side anchors already supported. | CLAUDE.md |
+| **YAML tags (`!!str`, `!<uri>`)** | ABAP target type (RTTI on DESERIALIZE, inference on GENERATE) already determines interpretation. Tags rare in config. | CLAUDE.md |
+| **Explicit block-scalar indent indicator (`\|2`, `>4`)** | Auto-detection from body content covers all real cases; explicit form addresses rare edge case. | CLAUDE.md |
+| **Default key case** | Keeping `pretty_mode-none` (UPPERCASE) for consistency with Z_UI2_JSON. Users should pass `pretty_name = pretty_mode-low_case` for lowercase. Caveat: consecutive-capitals names (e.g. MY_URL) don't round-trip under camelCase inverse. | CLAUDE.md |
 
 ---
 
 ## Open Requests
 
 *(none yet)*
+

--- a/docs/superpowers/plans/2026-07-30-z_ui2_yaml.md
+++ b/docs/superpowers/plans/2026-07-30-z_ui2_yaml.md
@@ -1,0 +1,999 @@
+# Z_UI2_YAML Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a self-contained ABAP YAML 1.2 serializer/deserializer class `Z_UI2_YAML` for reading and producing configuration YAML files.
+
+**Architecture:** One scan of the text → lightweight node tree → dual mapper (typed RTTI / untyped optimized). Six local units inside one class: `lcl_scanner`, `lcl_parser`, node tree, `lcl_typed_mapper`, `lcl_gen_mapper`, `lcl_emitter`. Public class `Z_UI2_YAML` is a thin facade mirroring `Z_UI2_JSON`'s shape.
+
+**Tech Stack:** ABAP (SAP_BASIS 7.57+), abapGit source format, ABAP Unit, RTTI (`CL_ABAP_TYPEDESCR` family). Development/test system: **ER1** via sap-adt MCP.
+
+## Global Constraints
+
+- **Min SAP_BASIS: 7.57+** — modern ABAP allowed (inline decls, string templates, `VALUE`/`CORRESPONDING`/`REDUCE`, table expressions).
+- **Fully self-contained** — no code/logic dependency on `Z_UI2_JSON`/`Z_UI2_JSON2`. Locals live in class includes. No new exception classes — reuse `CX_SY_CONVERSION_ERROR` (structural) and `CX_SY_MOVE_CAST_ERROR` (strict type mismatch).
+- **Target spec: YAML 1.2.**
+- **GENERATE always optimized** — typed tables + directly-typed struct components, never `REF TO data` wrappers. Type detection by character checks, no regex.
+- **Narrow static API** — advanced switches on `CONSTRUCTOR` only.
+- **Test cycle is in-system:** every "run test" step = `SaveClassTestInclude` → `ActivateObject` → `RunAbapUnit` on ER1 via sap-adt MCP. There is no local CLI. Commit to the local git repo after each green task.
+- **src/ mirrors the SAP system** — after any ADT save, update the matching `src/*.abap` file so the repo stays in sync.
+
+---
+
+## File Structure
+
+- `src/z_ui2_yaml.clas.abap` — main class: public API (`SERIALIZE`/`DESERIALIZE`/`GENERATE` + `_INT` + `CONSTRUCTOR`), local class **definitions**, facade logic.
+- `src/z_ui2_yaml.clas.locals_imp.abap` — implementations of `lcl_scanner`, `lcl_parser`, `lcl_typed_mapper`, `lcl_gen_mapper`, `lcl_emitter`.
+- `src/z_ui2_yaml.clas.testclasses.abap` — ABAP Unit tests.
+- `src/z_ui2_yaml.clas.xml` — abapGit metadata (generated on first create).
+- `src/z_ui2_yaml_perf.clas.abap` (+ `.testclasses.abap`, `.xml`) — performance harness (baseline only).
+- `docs/feature-requests-yaml.md` — own feature tracking, separate from JSON.
+
+### Shared local type contracts (defined in Task 1, used everywhere)
+
+```abap
+" node kinds
+CONSTANTS: BEGIN OF c_node,
+             scalar   TYPE i VALUE 0,
+             sequence TYPE i VALUE 1,
+             mapping  TYPE i VALUE 2,
+           END OF c_node.
+
+TYPES: BEGIN OF ty_node,
+         kind     TYPE i,              " c_node-*
+         value    TYPE string,         " scalar text (raw, unquoted/unescaped); style-resolved
+         is_null  TYPE abap_bool,      " true for ~ / empty value
+         children TYPE REF TO data,    " points to a ty_children table (see below)
+         anchor   TYPE string,         " anchor name registered on this node (or empty)
+       END OF ty_node,
+       ty_node_ref TYPE REF TO ty_node.
+
+" a mapping child carries its key; a sequence child leaves key empty
+TYPES: BEGIN OF ty_child,
+         key  TYPE string,
+         node TYPE ty_node_ref,
+       END OF ty_child,
+       ty_children TYPE STANDARD TABLE OF ty_child WITH DEFAULT KEY.
+
+" scanner output line
+TYPES: BEGIN OF ty_line,
+         indent      TYPE i,           " leading-space count (tabs are rejected)
+         content     TYPE string,      " comment-stripped, right-trimmed
+         lineno      TYPE i,           " 1-based, for error messages
+         is_doc_end  TYPE abap_bool,   " '...' marker
+       END OF ty_line,
+       ty_lines TYPE STANDARD TABLE OF ty_line WITH DEFAULT KEY.
+```
+
+> **Node children storage:** `children` is `REF TO data` pointing at a `ty_children` table, created with `CREATE DATA node->children TYPE ty_children`. Access via a field-symbol. This keeps `ty_node` self-referential without an illegal direct recursive include.
+
+---
+
+### Task 1: Class skeleton + shared local types + empty test harness
+
+**Files:**
+- Create: `src/z_ui2_yaml.clas.abap`
+- Create: `src/z_ui2_yaml.clas.locals_imp.abap`
+- Create: `src/z_ui2_yaml.clas.testclasses.abap`
+- Create (SAP): class `Z_UI2_YAML` via `CreateSession` + `SaveClass` on ER1
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: local type contracts above (`ty_node`, `ty_node_ref`, `ty_child`, `ty_children`, `ty_line`, `ty_lines`, `c_node`); public class shell with `pretty_mode`/`c_bool` constants copied from `Z_UI2_JSON`; empty `lcl_scanner`/`lcl_parser`/`lcl_typed_mapper`/`lcl_gen_mapper`/`lcl_emitter` class definitions.
+
+- [ ] **Step 1: Create the local class definitions in the CCDEF (class-relevant local types) section**
+
+In `z_ui2_yaml.clas.abap`, in the "local class definition" area (abapGit puts local defs in the main include for a simple class; use the class's local definitions include if the system splits it). Define the shared types and empty local classes:
+
+```abap
+CLASS lcl_scanner DEFINITION.
+  PUBLIC SECTION.
+    " filled in Task 2
+ENDCLASS.
+CLASS lcl_parser DEFINITION.
+  PUBLIC SECTION.
+    " filled in Task 4
+ENDCLASS.
+CLASS lcl_typed_mapper DEFINITION.
+  PUBLIC SECTION.
+ENDCLASS.
+CLASS lcl_gen_mapper DEFINITION.
+  PUBLIC SECTION.
+ENDCLASS.
+CLASS lcl_emitter DEFINITION.
+  PUBLIC SECTION.
+ENDCLASS.
+```
+
+Put the shared `TYPES`/`CONSTANTS` block (from "Shared local type contracts" above) at the top of the local definitions so all locals see it.
+
+- [ ] **Step 2: Create the public class shell**
+
+```abap
+CLASS z_ui2_yaml DEFINITION PUBLIC CREATE PUBLIC.
+  PUBLIC SECTION.
+    TYPES yaml TYPE string.
+    TYPES pretty_name_mode TYPE c LENGTH 1.
+    TYPES: BEGIN OF name_mapping,
+             abap TYPE abap_compname,
+             yaml TYPE string,
+           END OF name_mapping.
+    TYPES name_mappings TYPE HASHED TABLE OF name_mapping WITH UNIQUE KEY abap.
+    CONSTANTS: BEGIN OF pretty_mode,
+                 none        TYPE c LENGTH 1 VALUE ``,
+                 low_case    TYPE c LENGTH 1 VALUE 'L',
+                 camel_case  TYPE c LENGTH 1 VALUE 'X',
+                 pascal_case TYPE c LENGTH 1 VALUE 'P',
+                 extended    TYPE c LENGTH 1 VALUE 'Y',
+               END OF pretty_mode.
+    CONSTANTS version TYPE i VALUE 1.
+    " methods added in Tasks 8-11
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+CLASS z_ui2_yaml IMPLEMENTATION.
+ENDCLASS.
+```
+
+- [ ] **Step 3: Create a smoke test in the testclass include**
+
+```abap
+CLASS ltc_smoke DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS version_is_one FOR TESTING.
+ENDCLASS.
+CLASS ltc_smoke IMPLEMENTATION.
+  METHOD version_is_one.
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>version exp = 1 ).
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 4: Create + activate the class on ER1, then run the smoke test**
+
+Use sap-adt MCP: `CreateSession` (system_id=ER1) → `SaveClass` (main source) → `SaveClassTestInclude` → `ActivateObject` → `RunAbapUnit` on `Z_UI2_YAML`.
+Expected: PASS (`version_is_one`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/z_ui2_yaml.clas.abap src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap src/z_ui2_yaml.clas.xml
+git commit -m "feat(z_ui2_yaml): class skeleton + shared local types"
+```
+
+---
+
+### Task 2: Scanner — indentation, comment stripping, doc markers, tab rejection
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (implement `lcl_scanner`)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: `ty_lines`, `ty_line` from Task 1.
+- Produces:
+  ```abap
+  CLASS-METHODS scan
+    IMPORTING text TYPE string
+    RETURNING VALUE(lines) TYPE ty_lines
+    RAISING cx_sy_conversion_error.
+  ```
+  Behavior: splits on newlines; for each line computes `indent` (count of leading spaces), strips `#` comments **only when the `#` is at start-of-content or preceded by whitespace** (a `#` inside a value like `a#b` is literal), right-trims `content`, sets `lineno`. Blank lines and comment-only lines are **dropped**. A line `---` is dropped (single-doc start). A line `...` sets nothing structural here — return it with `is_doc_end = abap_true` so the parser can stop. **A leading tab in indentation raises `cx_sy_conversion_error`** with message `Tab in indentation at line N`. Block-scalar body handling is NOT done here (Task 6 re-reads raw lines) — scanner is line-level only.
+
+- [ ] **Step 1: Write the failing tests**
+
+```abap
+CLASS ltc_scanner DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS counts_indent          FOR TESTING.
+    METHODS strips_trailing_comment FOR TESTING.
+    METHODS keeps_hash_in_value    FOR TESTING.
+    METHODS drops_blank_and_comment FOR TESTING.
+    METHODS rejects_tab_indent     FOR TESTING.
+ENDCLASS.
+CLASS ltc_scanner IMPLEMENTATION.
+  METHOD counts_indent.
+    DATA(l) = lcl_scanner=>scan( |a: 1\n  b: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 1 ]-indent exp = 0 ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 2 ]-indent exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 2 ]-content exp = `b: 2` ).
+  ENDMETHOD.
+  METHOD strips_trailing_comment.
+    DATA(l) = lcl_scanner=>scan( |a: 1  # note| ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 1 ]-content exp = `a: 1` ).
+  ENDMETHOD.
+  METHOD keeps_hash_in_value.
+    DATA(l) = lcl_scanner=>scan( |a: v#alue| ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 1 ]-content exp = `a: v#alue` ).
+  ENDMETHOD.
+  METHOD drops_blank_and_comment.
+    DATA(l) = lcl_scanner=>scan( |a: 1\n\n# just a comment\nb: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = lines( l ) exp = 2 ).
+  ENDMETHOD.
+  METHOD rejects_tab_indent.
+    TRY.
+        lcl_scanner=>scan( |a:\n\tb: 2| ).
+        cl_abap_unit_assert=>fail( `expected tab rejection` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save test include, activate, run — verify FAIL**
+
+`SaveClassTestInclude` → `ActivateObject` → `RunAbapUnit`.
+Expected: FAIL (`scan` not implemented / methods empty).
+
+- [ ] **Step 3: Implement `lcl_scanner=>scan`**
+
+```abap
+METHOD scan.
+  DATA(rows) = |{ text }|.
+  SPLIT rows AT |\n| INTO TABLE DATA(raw).
+  LOOP AT raw INTO DATA(r).
+    DATA(n) = sy-tabix.
+    " reject tab in leading whitespace
+    DATA(lead) = r.
+    DATA off TYPE i VALUE 0.
+    WHILE off < strlen( lead ) AND ( lead+off(1) = ` ` OR lead+off(1) = |\t| ).
+      IF lead+off(1) = |\t|.
+        RAISE EXCEPTION TYPE cx_sy_conversion_error
+          EXPORTING value = |Tab in indentation at line { n }|.
+      ENDIF.
+      off = off + 1.
+    ENDWHILE.
+    DATA(indent) = off.
+    DATA(body) = r+off.
+    " strip a trailing "# ..." comment: '#' at start, or preceded by space
+    body = strip_comment( body ).      " helper below
+    " right-trim
+    SHIFT body RIGHT DELETING TRAILING space. CONDENSE body NO-GAPS.  "  -- see note
+    " NOTE: do NOT condense internal spaces; use a manual right-trim instead:
+    body = trim_right( body ).
+    IF body IS INITIAL.
+      CONTINUE.                         " blank or comment-only
+    ENDIF.
+    IF body = `---`.
+      CONTINUE.                         " single-doc start marker
+    ENDIF.
+    DATA(line) = VALUE ty_line( indent = indent content = body lineno = n ).
+    IF body = `...`.
+      line-is_doc_end = abap_true.
+    ENDIF.
+    APPEND line TO lines.
+  ENDLOOP.
+ENDMETHOD.
+```
+
+Implement the two private helpers (add to `lcl_scanner` PRIVATE SECTION in Task 1's definition or here as CLASS-METHODS):
+
+```abap
+METHOD strip_comment.
+  " returns body with a trailing "# comment" removed; '#' must be at pos 0
+  " or preceded by a space. Quoted-string awareness is added in Task 5;
+  " for now handle the common unquoted case.
+  result = body.
+  DATA i TYPE i VALUE 0.
+  WHILE i < strlen( body ).
+    IF body+i(1) = '#' AND ( i = 0 OR body+(i)(1) = space ).
+      " actually check preceding char:
+    ENDIF.
+    i = i + 1.
+  ENDWHILE.
+  " simpler correct impl:
+  FIND FIRST OCCURRENCE OF REGEX `(^|\s)#` IN body MATCH OFFSET DATA(mo).
+  IF sy-subrc = 0.
+    result = body(mo).
+  ENDIF.
+ENDMETHOD.
+
+METHOD trim_right.
+  result = body.
+  WHILE strlen( result ) > 0 AND substring( val = result off = strlen( result ) - 1 len = 1 ) = ` `.
+    result = substring( val = result len = strlen( result ) - 1 ).
+  ENDWHILE.
+ENDMETHOD.
+```
+
+> **Reviewer note:** the `strip_comment` body above shows a dead first-loop — delete it, keep only the `FIND ... REGEX` version. The regex `(^|\s)#` is a one-time compiled literal, acceptable here (scanner, not a per-node hot path). Quoted-`#` awareness is deferred to Task 5 where quote scanning exists.
+
+- [ ] **Step 4: Save, activate, run — verify PASS**
+
+Expected: PASS (all 5 scanner tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): scanner — indent, comments, doc markers, tab rejection"
+```
+
+---
+
+### Task 3: Node-tree helpers (create node, append child, read children)
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (add a small `lcl_tree` helper or static methods on the parser)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: `ty_node`, `ty_node_ref`, `ty_children`, `c_node` from Task 1.
+- Produces (on a new `lcl_tree` class):
+  ```abap
+  CLASS-METHODS new_scalar IMPORTING value TYPE string is_null TYPE abap_bool DEFAULT abap_false
+                           RETURNING VALUE(node) TYPE ty_node_ref.
+  CLASS-METHODS new_collection IMPORTING kind TYPE i RETURNING VALUE(node) TYPE ty_node_ref.
+  CLASS-METHODS add_child IMPORTING node TYPE ty_node_ref key TYPE string OPTIONAL child TYPE ty_node_ref.
+  CLASS-METHODS children IMPORTING node TYPE ty_node_ref RETURNING VALUE(ref) TYPE REF TO ty_children.
+  ```
+  `new_collection` allocates the `children` `REF TO data`. `add_child` appends a `ty_child`. `children` returns a typed ref to the child table (dereference with a field-symbol at call sites).
+
+- [ ] **Step 1: Write the failing test**
+
+```abap
+CLASS ltc_tree DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS build_mapping FOR TESTING.
+ENDCLASS.
+CLASS ltc_tree IMPLEMENTATION.
+  METHOD build_mapping.
+    DATA(m) = lcl_tree=>new_collection( c_node-mapping ).
+    lcl_tree=>add_child( node = m key = `a` child = lcl_tree=>new_scalar( `1` ) ).
+    lcl_tree=>add_child( node = m key = `b` child = lcl_tree=>new_scalar( `2` ) ).
+    DATA(kids) = lcl_tree=>children( m ).
+    FIELD-SYMBOLS <k> TYPE ty_children.
+    ASSIGN kids->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <k> ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 1 ]-key exp = `a` ).
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 1 ]-node->value exp = `1` ).
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL** (`lcl_tree` undefined).
+
+- [ ] **Step 3: Implement `lcl_tree`**
+
+```abap
+CLASS lcl_tree IMPLEMENTATION.
+  METHOD new_scalar.
+    node = NEW ty_node( kind = c_node-scalar value = value is_null = is_null ).
+  ENDMETHOD.
+  METHOD new_collection.
+    node = NEW ty_node( kind = kind ).
+    CREATE DATA node->children TYPE ty_children.
+  ENDMETHOD.
+  METHOD add_child.
+    FIELD-SYMBOLS <k> TYPE ty_children.
+    ASSIGN node->children->* TO <k>.
+    APPEND VALUE ty_child( key = key node = child ) TO <k>.
+  ENDMETHOD.
+  METHOD children.
+    ref ?= node->children.
+  ENDMETHOD.
+ENDCLASS.
+```
+
+> Add matching `CLASS lcl_tree DEFINITION` in Task 1's definition include (or here — keep def+impl together in locals_imp if the system allows; abapGit puts both in locals_imp).
+
+- [ ] **Step 4: Save, activate, run — verify PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): node-tree helpers"
+```
+
+---
+
+### Task 4: Parser — block mappings & sequences via indent stack
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (implement `lcl_parser`)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: `ty_lines` (Task 2), `lcl_tree` (Task 3).
+- Produces:
+  ```abap
+  CLASS-METHODS parse IMPORTING lines TYPE ty_lines
+                      RETURNING VALUE(root) TYPE ty_node_ref
+                      RAISING cx_sy_conversion_error.
+  ```
+  Recursive-descent over `lines` using an index cursor + current indent. A block whose first line matches `- ` (dash-space) or is exactly `-` → **sequence**; a first line containing an unquoted `: ` or ending `:` → **mapping**. `key:` with no inline value and a deeper block below → nested collection; with nothing below → null scalar. Bad dedent (indent that matches no open level) → `cx_sy_conversion_error` `Bad indentation at line N`. Scalars for now are the raw remainder text (quote/flow/block-scalar resolution comes in Tasks 5–6, layered on the same value slot).
+
+- [ ] **Step 1: Write the failing tests**
+
+```abap
+CLASS ltc_parser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS flat_mapping     FOR TESTING.
+    METHODS nested_mapping   FOR TESTING.
+    METHODS block_sequence   FOR TESTING.
+    METHODS seq_of_mappings  FOR TESTING.
+    METHODS key_null_value   FOR TESTING.
+    METHODS bad_dedent_fails FOR TESTING.
+    METHODS p IMPORTING t TYPE string RETURNING VALUE(r) TYPE ty_node_ref RAISING cx_sy_conversion_error.
+ENDCLASS.
+CLASS ltc_parser IMPLEMENTATION.
+  METHOD p.
+    r = lcl_parser=>parse( lcl_scanner=>scan( t ) ).
+  ENDMETHOD.
+  METHOD flat_mapping.
+    DATA(r) = p( |a: 1\nb: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = r->kind exp = c_node-mapping ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 1 ]-key exp = `a` ).
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 1 ]-node->value exp = `1` ).
+  ENDMETHOD.
+  METHOD nested_mapping.
+    DATA(r) = p( |parent:\n  child: v| ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    DATA(pn) = <k>[ 1 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = pn->kind exp = c_node-mapping ).
+    FIELD-SYMBOLS <c> TYPE ty_children. ASSIGN lcl_tree=>children( pn )->* TO <c>.
+    cl_abap_unit_assert=>assert_equals( act = <c>[ 1 ]-key exp = `child` ).
+    cl_abap_unit_assert=>assert_equals( act = <c>[ 1 ]-node->value exp = `v` ).
+  ENDMETHOD.
+  METHOD block_sequence.
+    DATA(r) = p( |- x\n- y| ).
+    cl_abap_unit_assert=>assert_equals( act = r->kind exp = c_node-sequence ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <k> ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 2 ]-node->value exp = `y` ).
+  ENDMETHOD.
+  METHOD seq_of_mappings.
+    DATA(r) = p( |- name: a\n  port: 1\n- name: b\n  port: 2| ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <k> ) exp = 2 ).
+    DATA(first) = <k>[ 1 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = first->kind exp = c_node-mapping ).
+    FIELD-SYMBOLS <f> TYPE ty_children. ASSIGN lcl_tree=>children( first )->* TO <f>.
+    cl_abap_unit_assert=>assert_equals( act = <f>[ 1 ]-node->value exp = `a` ).
+  ENDMETHOD.
+  METHOD key_null_value.
+    DATA(r) = p( |a:\nb: 2| ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 1 ]-node->is_null exp = abap_true ).
+  ENDMETHOD.
+  METHOD bad_dedent_fails.
+    TRY.
+        p( |a:\n    b: 1\n   c: 2| ).   " c dedents to a level that doesn't exist
+        cl_abap_unit_assert=>fail( `expected bad dedent` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL.**
+
+- [ ] **Step 3: Implement `lcl_parser`**
+
+Recursive descent with a module-level cursor. Sketch (fill in exactly):
+
+```abap
+CLASS lcl_parser IMPLEMENTATION.
+  METHOD parse.
+    DATA(idx) = 1.
+    IF lines IS INITIAL.
+      root = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
+      RETURN.
+    ENDIF.
+    root = parse_block( EXPORTING lines = lines min_indent = lines[ 1 ]-indent
+                        CHANGING idx = idx ).
+  ENDMETHOD.
+
+  " parse_block: consumes all consecutive lines whose indent >= own_indent,
+  " where own_indent = indent of lines[idx]. Decides mapping vs sequence from
+  " the first line. Returns the collection (or a scalar for a lone value line).
+  METHOD parse_block.
+    DATA(own) = lines[ idx ]-indent.
+    DATA(first) = lines[ idx ]-content.
+    IF first CP `- *` OR first = `-`.
+      node = parse_sequence( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
+    ELSE.
+      node = parse_mapping( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD parse_mapping.
+    node = lcl_tree=>new_collection( c_node-mapping ).
+    WHILE idx <= lines( lines ) AND lines[ idx ]-indent = own_indent.
+      DATA(c) = lines[ idx ]-content.
+      IF lines[ idx ]-is_doc_end = abap_true. idx = idx + 1. EXIT. ENDIF.
+      split_key_value( EXPORTING content = c lineno = lines[ idx ]-lineno
+                       IMPORTING key = DATA(key) inline_value = DATA(val) has_inline = DATA(has_val) ).
+      idx = idx + 1.
+      DATA(child) = value_or_block( EXPORTING lines = lines own_indent = own
+                                     has_inline = has_val inline_value = val
+                                     CHANGING idx = idx ).
+      lcl_tree=>add_child( node = node key = key child = child ).
+    ENDWHILE.
+    check_no_shallower_orphan( lines = lines idx = idx own_indent = own ).
+  ENDMETHOD.
+
+  METHOD parse_sequence.
+    node = lcl_tree=>new_collection( c_node-sequence ).
+    WHILE idx <= lines( lines ) AND lines[ idx ]-indent = own_indent
+                                AND ( lines[ idx ]-content CP `- *` OR lines[ idx ]-content = `-` ).
+      DATA(rest) = COND string( WHEN lines[ idx ]-content = `-` THEN ``
+                                ELSE substring( val = lines[ idx ]-content off = 2 ) ).
+      " '- key: v' → the item is a mapping starting at column own+2.
+      " Rewrite current line's content to `rest` at a virtual indent = own+2,
+      " then recurse. Implementation: build a sub-lines table for this item.
+      DATA(child) = parse_seq_item( EXPORTING lines = lines own_indent = own rest = rest
+                                     CHANGING idx = idx ).
+      lcl_tree=>add_child( node = node child = child ).
+    ENDWHILE.
+  ENDMETHOD.
+```
+
+> **Reviewer/implementer note — the seq-item indentation trick:** a `- ` item can carry either a scalar (`- x`) or an inline mapping/nested block (`- name: a` then `  port: 1`). The clean implementation: for the current sequence item, treat the dash + following spaces as indentation. Build a temporary `ty_lines` where the first line's content is `rest` at `indent = own+2` and subsequent lines (indent > own) are copied as-is, then call `parse_block` on that slice with a fresh cursor. Keep this in `parse_seq_item`. This avoids a separate code path for dash-items.
+>
+> Helpers to implement: `split_key_value` (find first unquoted `:` — for Task 4, "unquoted" = literal scan; quote-awareness lands in Task 5), `value_or_block` (if `has_inline` → scalar node from `inline_value`; elif next line indent > own → `parse_block`; else → null scalar), `check_no_shallower_orphan` / bad-dedent detection (if after consuming a block the cursor sits on a line whose indent is greater than `own` but was never opened, or an indent that matches no level on the stack → raise). The `bad_dedent_fails` test pins this.
+
+- [ ] **Step 4: Save, activate, run — verify PASS** (all 6 parser tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): block mapping & sequence parser"
+```
+
+---
+
+### Task 5: Scalar styles + inline flow collections
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (add scalar/flow resolution used by the parser)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: parser (Task 4), `lcl_tree` (Task 3).
+- Produces (on `lcl_parser`, private):
+  ```abap
+  CLASS-METHODS resolve_scalar IMPORTING raw TYPE string
+                               EXPORTING value TYPE string is_null TYPE abap_bool
+                               RAISING cx_sy_conversion_error.
+  CLASS-METHODS parse_flow IMPORTING raw TYPE string
+                           RETURNING VALUE(node) TYPE ty_node_ref
+                           RAISING cx_sy_conversion_error.
+  ```
+  `resolve_scalar`: `'single'` → unquote + `''`→`'`; `"double"` → unquote + process `\n \t \" \\ \uXXXX`; `~` or empty → `is_null`; plain → as-is (trimmed). Unterminated quote → raise. `parse_flow`: an inline char cursor over `{...}` / `[...]` (which may nest and contain quoted scalars) → node tree. `split_key_value` and `strip_comment` become quote-aware here.
+
+- [ ] **Step 1: Write the failing tests**
+
+```abap
+CLASS ltc_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS single_quote  FOR TESTING.
+    METHODS double_escapes FOR TESTING.
+    METHODS tilde_is_null  FOR TESTING.
+    METHODS flow_map       FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS flow_seq       FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS colon_in_quotes FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS unterminated_fails FOR TESTING.
+ENDCLASS.
+CLASS ltc_scalar IMPLEMENTATION.
+  METHOD single_quote.
+    lcl_parser=>resolve_scalar( EXPORTING raw = `'it''s'` IMPORTING value = DATA(v) is_null = DATA(n) ).
+    cl_abap_unit_assert=>assert_equals( act = v exp = `it's` ).
+  ENDMETHOD.
+  METHOD double_escapes.
+    lcl_parser=>resolve_scalar( EXPORTING raw = `"a\tb"` IMPORTING value = DATA(v) is_null = DATA(n) ).
+    cl_abap_unit_assert=>assert_equals( act = v exp = |a\tb| ).
+  ENDMETHOD.
+  METHOD tilde_is_null.
+    lcl_parser=>resolve_scalar( EXPORTING raw = `~` IMPORTING value = DATA(v) is_null = DATA(n) ).
+    cl_abap_unit_assert=>assert_equals( act = n exp = abap_true ).
+  ENDMETHOD.
+  METHOD flow_map.
+    DATA(r) = lcl_parser=>parse_flow( `{a: 1, b: 2}` ).
+    cl_abap_unit_assert=>assert_equals( act = r->kind exp = c_node-mapping ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 2 ]-key exp = `b` ).
+  ENDMETHOD.
+  METHOD flow_seq.
+    DATA(r) = lcl_parser=>parse_flow( `[x, y, z]` ).
+    cl_abap_unit_assert=>assert_equals( act = r->kind exp = c_node-sequence ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <k> ) exp = 3 ).
+  ENDMETHOD.
+  METHOD colon_in_quotes.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |a: "x: y"| ) ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 1 ]-node->value exp = `x: y` ).
+  ENDMETHOD.
+  METHOD unterminated_fails.
+    TRY.
+        lcl_parser=>resolve_scalar( EXPORTING raw = `"oops` IMPORTING value = DATA(v) is_null = DATA(n) ).
+        cl_abap_unit_assert=>fail( `expected unterminated` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL.**
+
+- [ ] **Step 3: Implement `resolve_scalar` + `parse_flow`, and make `split_key_value`/`strip_comment` quote-aware**
+
+Implement per the interface contract. `resolve_scalar` handles `'`, `"`, `~`/empty, plain. `parse_flow` uses a single character cursor with a small recursive helper for nested `{}`/`[]`, calling `resolve_scalar` for each scalar token. Retrofit `split_key_value` to find the first `:` that is **not** inside quotes, and `strip_comment` to ignore `#` inside quotes. Wire `value_or_block` (Task 4) to call `resolve_scalar` for scalar values, and to call `parse_flow` when the inline value starts with `{` or `[`.
+
+- [ ] **Step 4: Save, activate, run — verify PASS** (7 tests + all Task 4 tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): scalar styles + inline flow collections"
+```
+
+---
+
+### Task 6: Block scalars (`|`, `>`) with chomping & folding
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (block-scalar handling in parser; needs raw indented lines)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: parser (Task 4/5).
+- Produces: block-scalar recognition inside `value_or_block`. When an inline value is `|`, `>`, `|-`, `|+`, `>-`, `>+` (optionally with an explicit indent digit), consume subsequent lines more-indented than the key, join per style:
+  - `|` literal: keep newlines. `>` folded: single newlines → spaces, blank lines → newline.
+  - Chomping: clip (default) → single trailing newline; strip (`-`) → none; keep (`+`) → all trailing.
+- **Scanner impact:** block-scalar bodies must NOT be comment-stripped or blank-dropped. Because Task 2's scanner drops those, block-scalar body lines are re-taken from the **raw** input. Simplest approach: give the parser access to the raw text lines (pass a parallel raw `ty_lines` that keeps blanks/comments and full content, indexed by `lineno`), and when a block scalar starts, read from the raw table. Add this raw table as a second output of `scan` (or a sibling `scan_raw`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```abap
+CLASS ltc_block_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS literal_keeps_newlines FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS folded_joins_lines     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS strip_chomp            FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS v IMPORTING t TYPE string RETURNING VALUE(r) TYPE string RAISING cx_sy_conversion_error.
+ENDCLASS.
+CLASS ltc_block_scalar IMPLEMENTATION.
+  METHOD v.
+    DATA(root) = lcl_parser=>parse( lcl_scanner=>scan( t ) ).  " see note on raw lines
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( root )->* TO <k>.
+    r = <k>[ 1 ]-node->value.
+  ENDMETHOD.
+  METHOD literal_keeps_newlines.
+    " key: |\n  line1\n  line2   → "line1\nline2\n"
+    cl_abap_unit_assert=>assert_equals( act = v( |k: \|\n  line1\n  line2| ) exp = |line1\nline2\n| ).
+  ENDMETHOD.
+  METHOD folded_joins_lines.
+    cl_abap_unit_assert=>assert_equals( act = v( |k: >\n  line1\n  line2| ) exp = |line1 line2\n| ).
+  ENDMETHOD.
+  METHOD strip_chomp.
+    cl_abap_unit_assert=>assert_equals( act = v( |k: \|-\n  line1| ) exp = `line1` ).
+  ENDMETHOD.
+ENDCLASS.
+```
+
+> **Note:** these tests require the scanner to expose raw lines. If the chosen implementation changes `scan`'s signature, update the earlier `p()`/`v()` helpers accordingly. Prefer adding `lcl_scanner=>scan_raw` returning a `ty_lines` that preserves everything, and have the parser accept both, defaulting raw = derived from the same text.
+
+- [ ] **Step 2: Save, activate, run — verify FAIL.**
+
+- [ ] **Step 3: Implement block-scalar consumption + chomping/folding**, wiring raw-line access into the parser.
+
+- [ ] **Step 4: Save, activate, run — verify PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): block scalars with chomping and folding"
+```
+
+---
+
+### Task 7: Anchors & aliases
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (anchor table in parser)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: parser (Tasks 4–6).
+- Produces: anchor handling in the parser. Recognize a leading `&name ` prefix on a value (scalar or start of a block) → after that node is fully built, store `name → ty_node_ref` in a `HASHED TABLE` keyed by name (instance/temporary state on the parse run). Recognize a value that is exactly `*name` → look up; **undefined name → `cx_sy_conversion_error`** `Undefined alias '*name' at line N`; found → set the child's node to the **same reference** (shared subtree). Anchors may appear on scalars, mappings, and sequences.
+
+- [ ] **Step 1: Write the failing tests**
+
+```abap
+CLASS ltc_anchor DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS scalar_alias      FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS mapping_alias      FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS undefined_alias_fails FOR TESTING.
+ENDCLASS.
+CLASS ltc_anchor IMPLEMENTATION.
+  METHOD scalar_alias.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |a: &v hello\nb: *v| ) ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 1 ]-node->value exp = `hello` ).
+    cl_abap_unit_assert=>assert_equals( act = <k>[ 2 ]-node->value exp = `hello` ).
+  ENDMETHOD.
+  METHOD mapping_alias.
+    " defaults: &d { timeout: 30 } ... then merge target references it
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |base: &d\n  timeout: 30\nother: *d| ) ).
+    FIELD-SYMBOLS <k> TYPE ty_children. ASSIGN lcl_tree=>children( r )->* TO <k>.
+    DATA(other) = <k>[ 2 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = other->kind exp = c_node-mapping ).
+    FIELD-SYMBOLS <o> TYPE ty_children. ASSIGN lcl_tree=>children( other )->* TO <o>.
+    cl_abap_unit_assert=>assert_equals( act = <o>[ 1 ]-node->value exp = `30` ).
+  ENDMETHOD.
+  METHOD undefined_alias_fails.
+    TRY.
+        lcl_parser=>parse( lcl_scanner=>scan( |a: *missing| ) ).
+        cl_abap_unit_assert=>fail( `expected undefined alias` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL.**
+
+- [ ] **Step 3: Implement anchor registration + alias resolution.** Add anchor-prefix stripping in the value/block entry points; register after building; resolve `*name` before constructing a fresh node.
+
+- [ ] **Step 4: Save, activate, run — verify PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): anchors and aliases on read"
+```
+
+---
+
+### Task 8: Typed mapper + DESERIALIZE (static + `_INT` + CONSTRUCTOR)
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.abap` (public methods, CONSTRUCTOR, `lcl_typed_mapper` def)
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (`lcl_typed_mapper` impl)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: node tree (Tasks 4–7).
+- Produces:
+  ```abap
+  " public
+  CLASS-METHODS deserialize IMPORTING yaml TYPE string OPTIONAL yamlx TYPE xstring OPTIONAL
+                                      pretty_name TYPE pretty_name_mode DEFAULT pretty_mode-none
+                                      name_mappings TYPE name_mappings OPTIONAL
+                            CHANGING data TYPE data.
+  METHODS deserialize_int IMPORTING yaml TYPE string OPTIONAL yamlx TYPE xstring OPTIONAL
+                          CHANGING data TYPE data
+                          RAISING cx_sy_move_cast_error.
+  METHODS constructor IMPORTING pretty_name TYPE pretty_name_mode DEFAULT pretty_mode-none
+                                name_mappings TYPE name_mappings OPTIONAL
+                                strict_mode TYPE abap_bool DEFAULT abap_false
+                                assoc_arrays TYPE abap_bool DEFAULT abap_false
+                                indent TYPE i DEFAULT 2
+                                emit_doc_markers TYPE abap_bool DEFAULT abap_false
+                                quote_style TYPE c LENGTH 1 DEFAULT 'P'   " P=plain-preferred, D=always-double
+                                flow_threshold TYPE i DEFAULT 0.
+  ```
+  `lcl_typed_mapper=>map` walks node vs `CL_ABAP_TYPEDESCR` of `data`: mapping→structure (match component names, apply name_mappings + pretty_name inverse), sequence→internal table, scalar→elementary (MOVE; scalar formatting for date/time/timestamp reuses character parsing). In strict mode a scalar that can't convert raises `cx_sy_move_cast_error` with path.
+
+- [ ] **Step 1: Write failing tests** (typed struct, nested, table of struct, strict failure). Example:
+
+```abap
+CLASS ltc_deser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS flat_struct   FOR TESTING.
+    METHODS table_of_struct FOR TESTING.
+    METHODS strict_bad_number FOR TESTING.
+ENDCLASS.
+CLASS ltc_deser IMPLEMENTATION.
+  METHOD flat_struct.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |name: web\nport: 8080| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-name exp = `web` ).
+    cl_abap_unit_assert=>assert_equals( act = out-port exp = 8080 ).
+  ENDMETHOD.
+  METHOD table_of_struct.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA out TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |- name: a\n  port: 1\n- name: b\n  port: 2| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = lines( out ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = out[ 2 ]-port exp = 2 ).
+  ENDMETHOD.
+  METHOD strict_bad_number.
+    TYPES: BEGIN OF ty, port TYPE i, END OF ty.
+    DATA out TYPE ty.
+    DATA(o) = NEW z_ui2_yaml( strict_mode = abap_true ).
+    TRY.
+        o->deserialize_int( EXPORTING yaml = |port: notanumber| CHANGING data = out ).
+        cl_abap_unit_assert=>fail( `expected cast error` ).
+      CATCH cx_sy_move_cast_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL.**
+- [ ] **Step 3: Implement CONSTRUCTOR, `deserialize_int` (scan→parse→map), static `deserialize` (instantiate + delegate), `lcl_typed_mapper=>map`.**
+- [ ] **Step 4: Save, activate, run — verify PASS.**
+- [ ] **Step 5: Commit** `feat(z_ui2_yaml): typed mapper + DESERIALIZE`
+
+---
+
+### Task 9: GENERATE (untyped, always-optimized)
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.abap` (public `generate`, `lcl_gen_mapper` def)
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (`lcl_gen_mapper` impl)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: node tree.
+- Produces:
+  ```abap
+  CLASS-METHODS generate IMPORTING yaml TYPE string RETURNING VALUE(rr_data) TYPE REF TO data.
+  ```
+  Builds a `REF TO data`: mapping → dynamically-created structure with directly-typed components; sequence with uniform element shape → typed STANDARD TABLE; scalar → typed elementary via **character-check** detection (integer / decimal / date `YYYY-MM-DD` / boolean `true`/`false` / else string). No `REF TO data` wrappers around leaf values, no regex.
+
+- [ ] **Step 1: Write failing tests** (generate a mapping, read a field via assign; generate a uniform sequence → typed table; type detection int vs string). Example:
+
+```abap
+CLASS ltc_gen DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS gen_mapping_field FOR TESTING.
+    METHODS gen_typed_int     FOR TESTING.
+ENDCLASS.
+CLASS ltc_gen IMPLEMENTATION.
+  METHOD gen_mapping_field.
+    DATA(r) = z_ui2_yaml=>generate( |host: localhost\nport: 5432| ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN r->* TO <s>.
+    FIELD-SYMBOLS <f> TYPE any. ASSIGN COMPONENT `HOST` OF STRUCTURE <s> TO <f>.
+    cl_abap_unit_assert=>assert_equals( act = <f> exp = `localhost` ).
+  ENDMETHOD.
+  METHOD gen_typed_int.
+    DATA(r) = z_ui2_yaml=>generate( |port: 5432| ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN r->* TO <s>.
+    FIELD-SYMBOLS <f> TYPE any. ASSIGN COMPONENT `PORT` OF STRUCTURE <s> TO <f>.
+    DATA(td) = cl_abap_typedescr=>describe_by_data( <f> ).
+    cl_abap_unit_assert=>assert_differs( act = td->type_kind exp = cl_abap_typedescr=>typekind_string ).
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL.**
+- [ ] **Step 3: Implement `lcl_gen_mapper` + `generate`.**
+- [ ] **Step 4: Save, activate, run — verify PASS.**
+- [ ] **Step 5: Commit** `feat(z_ui2_yaml): GENERATE untyped optimized`
+
+---
+
+### Task 10: Emitter + SERIALIZE (block style, quote-when-necessary)
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.abap` (public `serialize`/`serialize_int`, `lcl_emitter` def)
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (`lcl_emitter` impl)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap`
+
+**Interfaces:**
+- Consumes: RTTI of input `data`, CONSTRUCTOR options (indent, doc markers, quote_style, header_comment).
+- Produces:
+  ```abap
+  CLASS-METHODS serialize IMPORTING data TYPE data name TYPE string OPTIONAL
+                                    compress TYPE abap_bool DEFAULT abap_false
+                                    pretty_name TYPE pretty_name_mode DEFAULT pretty_mode-none
+                                    name_mappings TYPE name_mappings OPTIONAL
+                                    header_comment TYPE string OPTIONAL
+                          RETURNING VALUE(r_yaml) TYPE string.
+  METHODS serialize_int IMPORTING data TYPE data name TYPE string OPTIONAL
+                        RETURNING VALUE(r_yaml) TYPE string.
+  ```
+  RTTI walk → block YAML. **Quote-when-necessary:** a plain scalar is quoted (double, or per quote_style) if it contains `: `, ` #`, is empty, starts with a YAML indicator (`- ? : , [ ] { } # & * ! | > ' " % @ \``), or looks like a bool/null/number but the ABAP field is a string (to preserve type on round-trip). `compress` skips initial fields. `name`/`header_comment`/`emit_doc_markers` prepend as specified.
+
+- [ ] **Step 1: Write failing tests** (flat struct → block, nested, table → sequence, quoting for `:` and empty, round-trip). Example:
+
+```abap
+CLASS ltc_ser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS flat_struct   FOR TESTING.
+    METHODS quotes_colon  FOR TESTING.
+    METHODS round_trip    FOR TESTING.
+ENDCLASS.
+CLASS ltc_ser IMPLEMENTATION.
+  METHOD flat_struct.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA(in) = VALUE ty( name = `web` port = 8080 ).
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>serialize( in ) exp = |name: web\nport: 8080| ).
+  ENDMETHOD.
+  METHOD quotes_colon.
+    TYPES: BEGIN OF ty, t TYPE string, END OF ty.
+    DATA(in) = VALUE ty( t = `x: y` ).
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>serialize( in ) exp = |t: "x: y"| ).
+  ENDMETHOD.
+  METHOD round_trip.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA(in) = VALUE ty( name = `a: b` port = 7 ).
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = z_ui2_yaml=>serialize( in ) CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out exp = in ).
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL.**
+- [ ] **Step 3: Implement `lcl_emitter` + `serialize`/`serialize_int`.**
+- [ ] **Step 4: Save, activate, run — verify PASS.**
+- [ ] **Step 5: Commit** `feat(z_ui2_yaml): emitter + SERIALIZE with quote-when-necessary`
+
+---
+
+### Task 11: Real-world fixtures + perf harness + docs
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.testclasses.abap` (fixture round-trips)
+- Create: `src/z_ui2_yaml_perf.clas.abap` (+ `.testclasses.abap`, `.xml`)
+- Create: `docs/feature-requests-yaml.md`
+- Modify: `docs/basic.md` or new `docs/yaml.md` (usage), `CLAUDE.md` (register the class)
+
+**Interfaces:**
+- Consumes: full public API.
+- Produces: `Z_UI2_YAML_PERF=>run()` returning a typed results table (same shape/pattern as `Z_UI2_JSON_PERF`); testclass calls `cl_abap_unit_assert=>fail()` with formatted numbers. Baseline only — not a regression gate.
+
+- [ ] **Step 1: Write real-world fixture round-trip tests** — 3 fixtures: a CI-file-ish nested mapping+sequence, an app-config with block scalar, a list-of-servers. Each: parse into a matching typed structure and assert key values; and emit→parse round-trip.
+
+```abap
+CLASS ltc_fixtures DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS servers_list FOR TESTING.
+ENDCLASS.
+CLASS ltc_fixtures IMPLEMENTATION.
+  METHOD servers_list.
+    TYPES: BEGIN OF ty_s, host TYPE string, port TYPE i, END OF ty_s.
+    DATA servers TYPE STANDARD TABLE OF ty_s WITH DEFAULT KEY.
+    DATA(yaml) = |servers:\n  - host: a\n    port: 1\n  - host: b\n    port: 2|.
+    " deserialize into a wrapper struct { servers: table }
+    TYPES: BEGIN OF ty_w, servers TYPE STANDARD TABLE OF ty_s WITH DEFAULT KEY, END OF ty_w.
+    DATA w TYPE ty_w.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = yaml CHANGING data = w ).
+    cl_abap_unit_assert=>assert_equals( act = lines( w-servers ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = w-servers[ 2 ]-host exp = `b` ).
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, run — verify FAIL, then implement any gaps surfaced by real fixtures.** (This is the "validate against reality" step — fix parser/emitter bugs the synthetic tests missed.)
+- [ ] **Step 3: Create `Z_UI2_YAML_PERF`** mirroring `Z_UI2_JSON_PERF` structure; scenarios: serialize small config, deserialize small config, generate small config. Run once, record numbers.
+- [ ] **Step 4: Write docs** — `docs/feature-requests-yaml.md` (empty backlog + "own list, not mixed with JSON" note), a usage doc, and add `Z_UI2_YAML` to `CLAUDE.md` Architecture section. Note the documented v1 limitations (no anchor emission, single-doc, no tags).
+- [ ] **Step 5: Commit** `feat(z_ui2_yaml): fixtures, perf harness, docs`
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Scanner (indent/comments/tabs/doc-markers) → Task 2 ✓
+- Node tree → Tasks 1, 3 ✓
+- Block mapping/sequence → Task 4 ✓
+- Scalar styles + flow → Task 5 ✓
+- Block scalars + chomping/folding → Task 6 ✓
+- Anchors/aliases (read) → Task 7 ✓
+- Typed DESERIALIZE + strict + CONSTRUCTOR + name_mappings/pretty_name → Task 8 ✓
+- GENERATE always-optimized → Task 9 ✓
+- Emitter/SERIALIZE + quote-when-necessary + YAML-only params → Task 10 ✓
+- Real fixtures + perf baseline + own feature-requests + docs → Task 11 ✓
+- Self-contained, no new exception class, reuse `CX_SY_CONVERSION_ERROR`/`CX_SY_MOVE_CAST_ERROR` → enforced across Tasks 2,4,5,7,8 ✓
+- Dropped JSON legacy (no DUMP/ESCAPE/GEN_OPTIMIZE/etc.) → API never adds them ✓
+
+**Deferred (documented, per spec):** anchor *emission* on write, multi-document streams, tags — noted in Task 11 docs.
+
+**Type consistency:** node model (`ty_node`/`ty_node_ref`/`ty_child`/`ty_children`/`c_node`), `lcl_tree` methods (`new_scalar`/`new_collection`/`add_child`/`children`), `lcl_scanner=>scan`, `lcl_parser=>parse`/`resolve_scalar`/`parse_flow`, mapper/emitter/public signatures are consistent across tasks.
+
+**Open implementation risk (flagged, not a blocker):** Task 6's requirement that block-scalar bodies bypass comment-stripping forces the scanner to also expose raw lines. Task 6 specifies the `scan_raw` approach; if the implementer changes `scan`'s signature, earlier test helpers (`p()`, `v()`) must be updated in the same task.

--- a/docs/superpowers/plans/2026-07-31-z_ui2_yaml-deferrals.md
+++ b/docs/superpowers/plans/2026-07-31-z_ui2_yaml-deferrals.md
@@ -1,0 +1,286 @@
+# Z_UI2_YAML Deferral Resolution (Phase A) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the seven v1 deferrals — build #1 (camelCase inverse deserialize), #3 (block-header anchors), #4 (multi-doc streams); decline #2/#5/#6/#7 as logged decisions.
+
+**Architecture:** Additive changes to the existing `Z_UI2_YAML` class (branch `feat/z_ui2_yaml`, HEAD `eea66a4`, 65 tests pristine). #1 extends `lcl_typed_mapper` key-matching; #3 extends the scanner block-header + parser anchor registration; #4 adds a document splitter + two new public methods over the existing single-doc path. No rewrite of working code except the minimal scanner `---` change #4 needs.
+
+**Tech Stack:** ABAP (SAP_BASIS 7.57+), abapGit format, ABAP Unit, RTTI. Test system: **ER1** via sap-adt MCP.
+
+## Global Constraints
+
+- **Min SAP_BASIS 7.57+.** Modern ABAP.
+- **Self-contained** — no Z_UI2_JSON dependency. Structural errors → `cx_sy_conversion_no_number`; strict type mismatch → `cx_sy_move_cast_error`.
+- **PRISTINE test output** — no compiler warnings (use `substring( val = off = )` not `x+off`; PCRE or `##REGEX_POSIX` pragma; no redundant CONV; no unused vars).
+- **Perf-neutral when option unused** — #1's inverse transform guarded behind `pretty_name <> none`, only after a direct match fails.
+- **Static API narrow** — new methods are top-level (`GENERATE_ALL`/`DESERIALIZE_ALL`), not switches on existing ones. Existing `DESERIALIZE`/`GENERATE` behavior unchanged (first doc only).
+- **In-system test cycle:** every "run test" = `SaveClassInclude`/`SaveClassTestInclude` → `ActivateObject` → `RunAbapUnit` on ER1. Read ONLY the summary line from RunAbapUnit (never echo the full XML — it is ~25KB and will blow the output-token limit). Commit to git after each green task; mirror ER1 source into `src/`.
+- **OUTPUT DISCIPLINE for implementers:** keep streamed responses terse; RunAbapUnit summary lines only; full detail in the report file.
+
+## Current-state facts (authoritative — from v1 build)
+
+- Node contract: `ty_node_ref = REF TO lcl_node_ref`; `lcl_node_ref` has public `node TYPE ty_node` (kind char via `c_node=>scalar/mapping/sequence`, `value`, `is_null`) + `children TYPE ty_children` (direct table; `ty_child` = `key` + `node`).
+- `ty_line` fields: `lineno`, `indent`, `content`, `doc_marker` (set on `...`), `blk_scalar_hd`, `blk_value`. `---` lines are currently DROPPED by `lcl_scanner=>scan`.
+- Parser: `lcl_parser=>parse( lines ) RETURNING ty_node_ref`; helpers `parse_block`/`parse_mapping`/`parse_sequence`/`parse_seq_item`/`value_or_block`/`split_key_value`/`resolve_scalar`/`parse_flow`/`strip_anchor`/`resolve_alias`. Anchor table is a CLASS-DATA on `lcl_parser`, cleared at `parse()` entry.
+- Emitter: `lcl_emitter=>emit`; forward pretty_name transform (MY_FIELD→myField etc.) lives here — reuse its word-boundary logic (inverted) for #1.
+- Typed mapper: `lcl_typed_mapper=>map( node, pretty_name, name_mappings, strict CHANGING data )`; struct branch matches components by name_mappings + case-insensitive uppercase. Bool detection by `absolute_name CP` bool-type set.
+- Public class `z_ui2_yaml`: static `serialize`/`deserialize`/`generate` + `serialize_int`/`deserialize_int` + CONSTRUCTOR storing `mv_pretty_name`/`mt_name_mappings`/`mv_strict`/`mv_indent`/`mv_quote_style`/`mv_emit_doc_markers`/`mv_flow_threshold`. `pretty_mode` constants: none/low_case/camel_case/pascal_case/extended.
+- Tests: `src/z_ui2_yaml.clas.testclasses.abap`, 65 methods across 11 test classes (ltc_smoke, ltc_scanner, ltc_tree, ltc_parser, ltc_scalar, ltc_block_scalar, ltc_anchor, ltc_deser, ltc_gen, ltc_ser, ltc_fixtures).
+
+## File Structure
+
+All changes in existing files:
+- `src/z_ui2_yaml.clas.abap` — new public methods (#4), new `ref_tab` type.
+- `src/z_ui2_yaml.clas.locals_def.abap` — new `ty_line` field(s) (#3, #4); new local method signatures (#1 inverse helper, #4 splitter).
+- `src/z_ui2_yaml.clas.locals_imp.abap` — impls: #1 inverse match, #3 scanner+parser anchor, #4 splitter + generate_all/deserialize_all internals.
+- `src/z_ui2_yaml.clas.testclasses.abap` — new tests per task.
+- `docs/feature-requests-yaml.md`, `docs/yaml.md`, `CLAUDE.md` — Task 4 (docs/decisions).
+
+---
+
+### Task 1: #1 — camelCase/PascalCase inverse on DESERIALIZE
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_def.abap` (add private `pretty_inverse` method to `lcl_typed_mapper`)
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (`lcl_typed_mapper` struct-branch match + `pretty_inverse`)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap` (ltc_deser additions)
+
+**Interfaces:**
+- Consumes: `lcl_typed_mapper=>map` existing struct branch; `z_ui2_yaml=>pretty_mode` constants.
+- Produces:
+  ```abap
+  CLASS-METHODS pretty_inverse
+    IMPORTING yaml_key TYPE string pretty_name TYPE z_ui2_yaml=>pretty_name_mode
+    RETURNING VALUE(abap_name) TYPE string.
+  ```
+  Returns the ABAP component name for a YAML key under a pretty_name mode: camel/extended `myField`→`MYFIELD`... wait — the ABAP component is `MY_FIELD`. Transform: insert `_` before each interior uppercase letter, then upper-case the whole. `myField`→`MY_FIELD`; pascal `MyField`→`MY_FIELD`; `low_case`/`none`→`TO_UPPER( yaml_key )` (no underscore insertion — none/low have no camel boundaries). Only called after a direct match fails and `pretty_name <> none`.
+
+- [ ] **Step 1: Write the failing tests** (ltc_deser additions)
+
+```abap
+METHOD camel_inverse_deser.
+  TYPES: BEGIN OF ty, my_field TYPE string, another_one TYPE i, END OF ty.
+  DATA out TYPE ty.
+  DATA(o) = NEW z_ui2_yaml( pretty_name = z_ui2_yaml=>pretty_mode-camel_case ).
+  o->deserialize_int( EXPORTING yaml = |myField: hello\nanotherOne: 5| CHANGING data = out ).
+  cl_abap_unit_assert=>assert_equals( act = out-my_field exp = `hello` ).
+  cl_abap_unit_assert=>assert_equals( act = out-another_one exp = 5 ).
+ENDMETHOD.
+METHOD pascal_inverse_deser.
+  TYPES: BEGIN OF ty, my_field TYPE string, END OF ty.
+  DATA out TYPE ty.
+  DATA(o) = NEW z_ui2_yaml( pretty_name = z_ui2_yaml=>pretty_mode-pascal_case ).
+  o->deserialize_int( EXPORTING yaml = |MyField: hi| CHANGING data = out ).
+  cl_abap_unit_assert=>assert_equals( act = out-my_field exp = `hi` ).
+ENDMETHOD.
+METHOD camel_round_trip.
+  TYPES: BEGIN OF ty, my_field TYPE string, port_num TYPE i, END OF ty.
+  DATA(in) = VALUE ty( my_field = `x` port_num = 9 ).
+  DATA out TYPE ty.
+  DATA(o) = NEW z_ui2_yaml( pretty_name = z_ui2_yaml=>pretty_mode-camel_case ).
+  o->deserialize_int( EXPORTING yaml = o->serialize_int( in ) CHANGING data = out ).
+  cl_abap_unit_assert=>assert_equals( act = out exp = in ).
+ENDMETHOD.
+```
+Add the method declarations to ltc_deser DEFINITION.
+
+- [ ] **Step 2: Save test include, activate, RunAbapUnit — verify FAIL (RED).** Summary line only. Expected: the 3 new fail (keys don't match camelCase → fields stay initial).
+
+- [ ] **Step 3: Implement `pretty_inverse` + wire into the struct match.** In `lcl_typed_mapper=>map` struct branch: after the existing name_mappings + `TO_UPPER` match yields no component AND `pretty_name <> pretty_mode-none`, compute `pretty_inverse( yaml_key = child-key pretty_name = pretty_name )` and retry the component lookup with that name. `pretty_inverse`: walk chars, before each interior char that IS uppercase (offset>0) append `_`, then `TO_UPPER` the result; for none/low_case just `TO_UPPER`.
+
+- [ ] **Step 4: Save, activate, RunAbapUnit — verify PASS (GREEN), all 68, pristine.** Summary only.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "c:/Users/D038062/Documents/GitHub/abap-to-json"
+git add src/z_ui2_yaml.clas.locals_def.abap src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): camelCase/PascalCase inverse key mapping on DESERIALIZE"
+```
+
+---
+
+### Task 2: #3 — block-header anchors on read
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.locals_def.abap` (add `blk_anchor TYPE string` to `ty_line`)
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (scanner block-header: strip `&name`; parser: register on blk_scalar_hd consume)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap` (ltc_anchor additions)
+
+**Interfaces:**
+- Consumes: scanner block-header handling; `lcl_parser` anchor table + registration path (Task 7 v1); `blk_scalar_hd`/`blk_value` mechanism.
+- Produces: `ty_line-blk_anchor` carries the anchor name parsed off a block-scalar header line (empty if none). Parser registers it after building the block-scalar node.
+
+- [ ] **Step 1: Write the failing tests** (ltc_anchor additions)
+
+```abap
+METHOD block_header_anchor.
+  " anchor on a block-scalar header, then alias it
+  DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |a: &blk \|\n  line1\n  line2\nb: *blk| ) ).
+  DATA(av) = r->children[ 1 ]-node->node-value.
+  cl_abap_unit_assert=>assert_equals( act = av exp = |line1\nline2\n| ).
+  " alias b resolves to the same block value
+  cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = |line1\nline2\n| ).
+  " shared reference
+  cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node exp = r->children[ 2 ]-node ).
+ENDMETHOD.
+```
+Add `block_header_anchor FOR TESTING RAISING cx_sy_conversion_error` to ltc_anchor DEFINITION. NOTE: the `\|` in the template is an escaped pipe; verify the scanner sees `a: &blk |`.
+
+- [ ] **Step 2: Save, activate, RunAbapUnit — verify FAIL (RED).** Summary only. Expected: alias `*blk` → undefined-alias raise (anchor never registered because block header bypassed value_or_block).
+
+- [ ] **Step 3: Implement.**
+  - Add `blk_anchor TYPE string` to `ty_line` in locals_def.
+  - Scanner: when parsing a block-scalar header line, after isolating the `key:` prefix and before the `|`/`>` indicator, detect a leading `&name` token in the remainder; if present, strip it and set `line-blk_anchor = name`. (Reuse the same anchor-name validation as `strip_anchor`: `&` + `CO 'A-Za-z0-9_-'`.)
+  - Parser `parse_mapping`, in the `blk_scalar_hd = abap_true` branch: after `lv_child = lcl_tree=>new_scalar( value = cur-blk_value )`, if `cur-blk_anchor IS NOT INITIAL`, register `cur-blk_anchor → lv_child` in the anchor table (same insert the inline path uses).
+
+- [ ] **Step 4: Save, activate, RunAbapUnit — verify PASS (GREEN), all 69, pristine.** Summary only. Confirm prior block-scalar + anchor tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "c:/Users/D038062/Documents/GitHub/abap-to-json"
+git add src/z_ui2_yaml.clas.locals_def.abap src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): anchors on block-scalar header lines"
+```
+
+---
+
+### Task 3: #4 — multi-document streams (GENERATE_ALL + DESERIALIZE_ALL)
+
+**Files:**
+- Modify: `src/z_ui2_yaml.clas.abap` (public `generate_all`, `deserialize_all` + `deserialize_all_int`; `ref_tab` type)
+- Modify: `src/z_ui2_yaml.clas.locals_def.abap` (`doc_start` flag on `ty_line`; `split_documents` on `lcl_parser` or a helper)
+- Modify: `src/z_ui2_yaml.clas.locals_imp.abap` (scanner keep `---` as `doc_start`; single-doc `parse` skips leading `doc_start`; `split_documents`; generate_all/deserialize_all internals)
+- Test: `src/z_ui2_yaml.clas.testclasses.abap` (new ltc_multidoc)
+
+**Interfaces:**
+- Consumes: `lcl_scanner=>scan`, `lcl_parser=>parse`, `lcl_gen_mapper=>generate`, `lcl_typed_mapper=>map`.
+- Produces:
+  ```abap
+  " public class
+  TYPES ref_tab TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY.
+  CLASS-METHODS generate_all IMPORTING yaml TYPE string RETURNING VALUE(rt_data) TYPE ref_tab.
+  CLASS-METHODS deserialize_all IMPORTING yaml TYPE string
+                                          pretty_name TYPE pretty_name_mode DEFAULT pretty_mode-none
+                                          name_mappings TYPE name_mappings OPTIONAL
+                                CHANGING results TYPE STANDARD TABLE.
+  METHODS deserialize_all_int IMPORTING yaml TYPE string CHANGING results TYPE STANDARD TABLE
+                              RAISING cx_sy_move_cast_error.
+  " local
+  CLASS-METHODS split_documents IMPORTING lines TYPE ty_lines RETURNING VALUE(rt_blocks) TYPE ... (table of ty_lines).
+  ```
+  `split_documents` partitions the line stream at `doc_start` (`---`) boundaries into a table of `ty_lines` (one per document); `...` (`doc_marker`) ends the current document. A leading `---` does not create an empty leading doc. `generate_all`: scan → split → for each block, `parse` + `lcl_gen_mapper=>generate`, APPEND ref. `deserialize_all_int`: scan → split → for each block, create a `results` line workarea (via RTTI of the table's line type), `parse` + `lcl_typed_mapper=>map`, APPEND row. Structural errors propagate; static `generate_all`/`deserialize_all` mirror the narrow signature and instantiate+delegate.
+
+- [ ] **Step 1: Write the failing tests** (new ltc_multidoc class)
+
+```abap
+CLASS ltc_multidoc DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS generate_all_three FOR TESTING.
+    METHODS deserialize_all_typed FOR TESTING.
+    METHODS single_doc_degenerate FOR TESTING.
+    METHODS legacy_first_doc_only FOR TESTING.
+ENDCLASS.
+CLASS ltc_multidoc IMPLEMENTATION.
+  METHOD generate_all_three.
+    DATA(y) = |a: 1\n---\na: 2\n---\na: 3|.
+    DATA(rt) = z_ui2_yaml=>generate_all( y ).
+    cl_abap_unit_assert=>assert_equals( act = lines( rt ) exp = 3 ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN rt[ 2 ]->* TO <s>.
+    FIELD-SYMBOLS <f> TYPE any. ASSIGN COMPONENT `A` OF STRUCTURE <s> TO <f>.
+    cl_abap_unit_assert=>assert_equals( act = <f> exp = 2 ).
+  ENDMETHOD.
+  METHOD deserialize_all_typed.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA results TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    DATA(y) = |name: a\nport: 1\n---\nname: b\nport: 2|.
+    z_ui2_yaml=>deserialize_all( EXPORTING yaml = y CHANGING results = results ).
+    cl_abap_unit_assert=>assert_equals( act = lines( results ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = results[ 2 ]-name exp = `b` ).
+    cl_abap_unit_assert=>assert_equals( act = results[ 2 ]-port exp = 2 ).
+  ENDMETHOD.
+  METHOD single_doc_degenerate.
+    DATA(rt) = z_ui2_yaml=>generate_all( |a: 1| ).
+    cl_abap_unit_assert=>assert_equals( act = lines( rt ) exp = 1 ).
+  ENDMETHOD.
+  METHOD legacy_first_doc_only.
+    " existing DESERIALIZE on multi-doc returns doc 1 only (backward compat)
+    TYPES: BEGIN OF ty, a TYPE i, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a: 1\n---\na: 2| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-a exp = 1 ).
+  ENDMETHOD.
+ENDCLASS.
+```
+
+- [ ] **Step 2: Save, activate, RunAbapUnit — verify FAIL (RED).** Summary only. Expected: generate_all/deserialize_all undefined; legacy_first_doc_only may already pass or error depending on current `---` handling — note which.
+
+- [ ] **Step 3: Implement.**
+  - `ty_line`: add `doc_start TYPE abap_bool`. Scanner: instead of dropping `---`, emit a line with `doc_start = abap_true` (content empty, indent 0). Keep `...` → `doc_marker` as now.
+  - Single-doc `parse`: skip a leading `doc_start` line (so existing single-doc parse of `---\na: 1` still works and existing `DESERIALIZE`/`GENERATE` see the first doc only — process up to the first *subsequent* `doc_start`/`doc_marker` and ignore the rest, preserving current first-doc behavior).
+  - `split_documents( lines ) RETURNING table of ty_lines`: iterate; a `doc_start` closes the current block (if non-empty) and starts a new one; `doc_marker` closes the current block; collect non-boundary lines into the current block. Drop empty blocks.
+  - Public `generate_all`: scan → split_documents → loop blocks: `lcl_parser=>parse( block )` → `lcl_gen_mapper=>generate` → APPEND to rt_data.
+  - `deserialize_all_int`: scan → split → loop: build a line workarea from `results`' RTTI line type (CREATE DATA), `parse` + `map` into it, APPEND. static `deserialize_all` wraps (instantiate with pretty_name/name_mappings, TRY/CATCH cast error like `deserialize`).
+  - Add `ref_tab` type to public class.
+
+- [ ] **Step 4: Save, activate, RunAbapUnit — verify PASS (GREEN), all 73, pristine.** Summary only. CRITICAL regression check: all prior parser/scanner/deser/gen tests still green — confirm the scanner `---` change didn't break single-doc parsing (esp. any existing test using `---`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "c:/Users/D038062/Documents/GitHub/abap-to-json"
+git add src/z_ui2_yaml.clas.abap src/z_ui2_yaml.clas.locals_def.abap src/z_ui2_yaml.clas.locals_imp.abap src/z_ui2_yaml.clas.testclasses.abap
+git commit -m "feat(z_ui2_yaml): multi-document streams (GENERATE_ALL + DESERIALIZE_ALL)"
+```
+
+---
+
+### Task 4: Decline decisions + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (API Design Decisions: log #2/#5/#6 declines + #7 default-case decision)
+- Modify: `docs/feature-requests-yaml.md` (move built items out; add Declined section)
+- Modify: `docs/yaml.md` (document GENERATE_ALL/DESERIALIZE_ALL; camelCase deserialize now supported; block-header anchors supported; prominent low_case-for-lowercase-keys note; declined items as limitations)
+
+**Interfaces:**
+- Consumes: nothing (docs only). No ABAP, no tests.
+
+- [ ] **Step 1: Update CLAUDE.md** — add to "API Design Decisions" (durable, one paragraph each):
+  - `(Z_UI2_YAML) Anchor emission on write — declined.` Config producers emit expanded YAML; anchor emission needs cycle detection + dedup heuristic. Read-side anchors supported.
+  - `(Z_UI2_YAML) YAML tags — declined.` `!!str`/`!<uri>` rare in config; RTTI target type already determines interpretation. Silent-ignore stays.
+  - `(Z_UI2_YAML) Explicit block-scalar indent indicator (|N) — declined.` Auto-detection from first body line covers real content.
+  - `(Z_UI2_YAML) Default key case stays pretty_mode-none (uppercase passthrough).` Consistency with Z_UI2_JSON; changing is breaking. Users wanting conventional lowercase config keys pass `pretty_name = pretty_mode-low_case` (documented in yaml.md).
+
+- [ ] **Step 2: Update docs/feature-requests-yaml.md** — remove #1/#3/#4 from deferrals (now built); add a "## Declined (see CLAUDE.md)" section listing #2/#5/#6/#7 with a one-line reason + pointer.
+
+- [ ] **Step 3: Update docs/yaml.md** — add GENERATE_ALL/DESERIALIZE_ALL usage; note camelCase/Pascal deserialize now round-trips; note block-header anchors supported on read; add a prominent "Producing conventional lowercase keys → use pretty_name = pretty_mode-low_case (default none preserves ABAP uppercase)" callout; list declined items (tags/anchor-emission/|N) under Limitations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "c:/Users/D038062/Documents/GitHub/abap-to-json"
+git add CLAUDE.md docs/feature-requests-yaml.md docs/yaml.md
+git commit -m "docs(z_ui2_yaml): log declined deferrals + document new multi-doc/camelCase/anchor features"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #1 camelCase inverse deserialize → Task 1 ✓
+- #3 block-header anchors → Task 2 ✓
+- #4 multi-doc GENERATE_ALL + DESERIALIZE_ALL → Task 3 ✓
+- #2/#5/#6 declines + #7 default-case decision → Task 4 (CLAUDE.md) ✓
+- yaml.md/feature-requests-yaml.md updates → Task 4 ✓
+- Perf-neutral (#1 guarded behind pretty_name<>none) ✓; static API narrow (new top-level methods) ✓; backward compat (existing DESERIALIZE/GENERATE first-doc-only) ✓ Task 3 Step 4 regression check.
+
+**Placeholder scan:** none — all steps have concrete code or concrete doc content.
+
+**Type consistency:** `pretty_inverse` (Task 1), `blk_anchor`/`doc_start` ty_line fields (Tasks 2/3), `ref_tab`/`generate_all`/`deserialize_all`/`deserialize_all_int`/`split_documents` (Task 3) named consistently across interface + steps. Node contract (`->node-value`/`->children`) consistent with v1.
+
+**Ordering:** #1, #3, #4 independent enough; #3 and #4 both touch `ty_line` + scanner — sequence them (Task 2 before Task 3) so the second rebases on the first's committed state. Task 4 (docs) last, after all behavior is final.
+
+**Risk note:** Task 3's scanner `---` change is the only modification to working v1 behavior — Step 4's regression check across all prior tests is the guard.

--- a/docs/superpowers/plans/2026-07-31-z_ui2_yaml-phaseB-fixes.md
+++ b/docs/superpowers/plans/2026-07-31-z_ui2_yaml-phaseB-fixes.md
@@ -1,0 +1,82 @@
+# Z_UI2_YAML Phase B — Review Fixes & Optimization Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox syntax.
+
+**Goal:** Apply the Phase B findings — fix 5 correctness bugs, consolidate duplication (reuse), and polish maintainability — on the complete Z_UI2_YAML class without changing documented behavior (except the two approved fixes: CRLF normalization, null-keyword recognition).
+
+**Architecture:** Three sequential tasks on branch `feat/z_ui2_yaml` (HEAD `bb411ce`, 74 tests pristine). Task 1 = correctness (TDD, behavior changes where approved). Task 2 = reuse consolidation (behavior-preserving). Task 3 = maintainability polish (behavior-preserving). Findings sourced from `c:/tmp/yaml-phaseB-{correctness,reuse,maintainability}.md`.
+
+**Tech Stack:** ABAP 7.57+, ER1 via sap-adt MCP, ABAP Unit.
+
+## Global Constraints
+- SAP_BASIS 7.57+, self-contained (no Z_UI2_JSON), PRISTINE tests, structural errors → `cx_sy_conversion_no_number`, strict → `cx_sy_move_cast_error`, perf-neutral, static API narrow.
+- In-system TDD: SaveClassInclude/TestInclude → ActivateObject → RunAbapUnit on ER1. **RunAbapUnit summary line ONLY — never echo full XML (32k output-limit trap).** Commit after each green task; mirror ER1 source into `src/`.
+- Behavior-preserving tasks (2, 3): all 74 existing tests must stay green with NO test changes (proves no behavior drift). New tests only where a task adds/fixes behavior.
+
+## Current-state facts
+Node: `ty_node_ref = REF TO lcl_node_ref` (node + children). Locals: lcl_scanner/lcl_parser/lcl_typed_mapper/lcl_gen_mapper/lcl_emitter/lcl_tree in locals_imp; types + c_node in locals_def. Public class z_ui2_yaml. 74 tests across 11 ltc_ classes.
+
+---
+
+### Task 1: Correctness fixes (C1–C5)
+
+**Files:** `src/z_ui2_yaml.clas.abap`, `src/z_ui2_yaml.clas.locals_imp.abap`, `src/z_ui2_yaml.clas.testclasses.abap`
+
+Five distinct fixes, each with a RED test first:
+
+- **C1 — static DESERIALIZE must not dump on structural errors.** `deserialize`/`deserialize_all` (clas.abap ~157/213) catch only `cx_sy_move_cast_error`, but scan/parse raise `cx_sy_conversion_no_number`. Per the documented "lenient" contract, static DESERIALIZE must NOT dump. Fix: in static `deserialize`/`deserialize_all`, also `CATCH cx_sy_conversion_error` (parent of the structural subclass) and treat as lenient no-op (leave data as-is). NOTE: keep `deserialize_int` (instance) propagating structural errors — the fix is on the STATIC lenient face only. Decide + document: does lenient static swallow structural silently, or leave data initial? → swallow (return with data untouched), matching "lenient" = best-effort. Test: `deserialize( yaml = |a:\n\tb: 1| CHANGING out )` does NOT dump (out stays initial); a bad-dedent + unterminated-quote likewise.
+- **C2 — CRLF normalization.** `scan` splits on `|\n|`, leaving trailing `\r`. Fix: after the split (or in trim_right), strip a single trailing `\r` (0x0D) from each raw line before processing. Handles CRLF + mixed. Test: `scan(|port: 8080\r\nname: web|)` → line 1 content `port: 8080` (no CR), and a typed deser of CRLF input gives port=8080 (not 0).
+- **C3 — negative packed decimal trailing sign.** emitter numeric branch: `TYPE p` negative emits `3.14-`. Fix: after converting the numeric elem to string, detect a trailing `-` and move it to the front (`3.14-` → `-3.14`). Apply only to the packed/numeric path; leave i/decfloat (already leading-sign) untouched. Test: struct field `TYPE p DECIMALS 2 = '-3.14'` serializes to `...: -3.14`.
+- **C4 — recognize null/Null/NULL.** `resolve_scalar`: currently only `~`/empty → is_null. Add: unquoted value exactly `null`/`Null`/`NULL` → is_null=true, value=``. (Quoted `"null"` stays the string — resolve_scalar handles quotes before this check.) Test: `deserialize(|a: null|)` into a string field → initial/empty; `generate(|a: null|)` → null handling; a quoted `|a: "null"|` stays string `null`.
+- **C5 — indent_block hardcoded n=2.** emitter table-row branch (locals_imp ~1329) uses `indent_block( n = 2 )` ignoring `indent_step`. Fix: `n = indent_step`. Test: an instance with `indent = 4` serializing a table-of-struct → continuation lines indented by 4 (assert the emitted string, or round-trip with indent=4).
+
+- [ ] **Step 1:** Write 5 RED tests (add to relevant ltc_ classes or a new ltc_phaseb). Save test include → activate → RunAbapUnit → confirm the new ones RED (summary only).
+- [ ] **Step 2:** Implement C1–C5. Save → activate → RunAbapUnit → GREEN, all (74 + new), pristine.
+- [ ] **Step 3:** Mirror src → commit `fix(z_ui2_yaml): structural-error leniency, CRLF, packed sign, null keyword, indent_step`.
+
+---
+
+### Task 2: Reuse consolidation (behavior-preserving)
+
+**Files:** `src/z_ui2_yaml.clas.locals_def.abap`, `src/z_ui2_yaml.clas.locals_imp.abap` (NO test changes — all 74+ must stay green unchanged)
+
+Apply reuse findings #1,#2,#3,#4,#6,#7,#8,#9 (skip #5 scan/strip_anchor cross-class merge = MED/optional, skip #10 quote-state-machine = HIGH/declined):
+- **#1** Extract `is_bool_type( eld ) RETURNING abap_bool` (the `CP *ABAP_BOOL*...` set) into a shared local (e.g. lcl_tree or a small util); call from lcl_typed_mapper + lcl_emitter. One source of truth.
+- **#2** `CONSTANTS c_yaml_name_chars` in locals_def; replace the 3 verbatim 62-char CO literals.
+- **#3** Collapse camel/pascal loops in `format_key` into one (initial-cap flag from pretty_name). Delete the `2`-suffixed clone (~18 lines).
+- **#4** Extract `is_date_like( value ) RETURNING abap_bool`; call from emitter quote_scalar + gen_mapper detect_scalar_type.
+- **#6** Sequence double-generation in gen_mapper: collect child refs in the uniformity pass, reuse in fill (halve RTTI allocs). Behavior identical.
+- **#7** `split_documents` always returns ≥1 block; remove the duplicated degenerate branches in generate_all + deserialize_all_int.
+- **#8** Inline single-caller `looks_like_number` into quote_scalar; delete the method decl.
+- **#9** `trim_right` strlen micro-optimization (compute length once, decrement).
+
+- [ ] **Step 1:** Apply all consolidations. Save def+impl → activate → RunAbapUnit → all 74+ GREEN with NO test changes (this is the behavior-preservation proof), pristine.
+- [ ] **Step 2:** Mirror src → commit `refactor(z_ui2_yaml): consolidate bool/date/name-char/case-loop duplication`.
+
+---
+
+### Task 3: Maintainability polish (behavior-preserving)
+
+**Files:** `src/z_ui2_yaml.clas.abap`, `src/z_ui2_yaml.clas.locals_def.abap`, `src/z_ui2_yaml.clas.locals_imp.abap` (NO test behavior changes — 74+ stay green)
+
+- **quote_mode constants:** add `CONSTANTS: BEGIN OF quote_mode, plain VALUE 'P', always_double VALUE 'D', END OF quote_mode.` to public class; replace `'P'`/`'D'` magic chars in constructor + quote_scalar. (Keeps quote_style TYPE c; just names the values.)
+- **Rename cryptic vars:** in scan (`rr`→lv_raw_line, `nn`→lv_next_n, `bbrr`→lv_body_raw, `bsl`→lv_stripped_ln, `blk_ind`→blk_scalar_ind to disambiguate from blk_ind_col); in parse_flow (`tsq`→in_sq, `tdq`→in_dq, `tdepth`→depth, `fc`→lv_colon_found). Match the in_sq/in_dq convention used elsewhere.
+- **Extract scan() helpers:** pull block-body collection + block-value assembly into 2 private class-methods (`collect_block_body`, `assemble_block_value`) so scan drops from ~283 to ~80 lines. Behavior identical.
+- **Dead code / polish:** delete unused `lv_last` (indent_block ~1577); delete empty `PROTECTED SECTION` (clas.abap); `c_max_comp_name_len TYPE i VALUE 30` constant in gen_mapper (replace the 2 magic 30s); move `aname` decl before its IF for clarity; drop redundant `strlen>0` guard after `IS NOT INITIAL`.
+- **Comment:** upgrade the anchor-table ponytail comment to note class-data is not thread-safe (concurrent parse() corrupts anchor state).
+
+- [ ] **Step 1:** Apply polish. Save all → activate → RunAbapUnit → all 74+ GREEN, NO test changes, pristine.
+- [ ] **Step 2:** Mirror src → commit `refactor(z_ui2_yaml): quote_mode constants, clearer names, split scan(), dead-code`.
+
+---
+
+## Deliberately NOT done (logged, not fixed)
+- Reuse #10 (triple quote-state-machine extraction) — HIGH risk, parse_flow too interleaved; not worth it.
+- Reuse #5 (scan re-implements strip_anchor cross-class) — MED, optional; skipped to keep the diff safe.
+- Correctness #5 (flow-on-own-line) + #6 (strict kind-mismatch) — exotic/low-value for config; note as accepted limitations if worth a doc line.
+
+## Self-Review
+- Coverage: 5 correctness (C1–C5) → Task 1; reuse #1-4,6-9 → Task 2; maintainability meaningful+nitpick → Task 3. ✓
+- Behavior-preservation guard: Tasks 2 & 3 forbid test changes, so 74 green = no drift. ✓
+- Approved behavior changes (CRLF, null) isolated to Task 1 with new tests. ✓
+- Perf baseline (Z_UI2_YAML_PERF create) remains a manual step — not in this plan. ✓

--- a/docs/superpowers/specs/2026-07-30-z_ui2_yaml-design.md
+++ b/docs/superpowers/specs/2026-07-30-z_ui2_yaml-design.md
@@ -1,0 +1,146 @@
+# Z_UI2_YAML — Design Spec
+
+**Date:** 2026-07-30
+**Status:** Design approved — ready for implementation plan
+**Related:** [kb/z_ui2_yaml-evaluation.md](../../../kb/z_ui2_yaml-evaluation.md) (feasibility)
+
+## Purpose
+
+A self-contained ABAP YAML serializer/deserializer, `Z_UI2_YAML`, for **reading and producing configuration YAML files**. Target spec: **YAML 1.2**. API and feature design based on `Z_UI2_JSON`; JSON-only specialties dropped, YAML-only specialties added on top.
+
+**Fully independent from `Z_UI2_JSON`:** no code or logic sharing. Only shared concern is feature tracking (own feature-requests list, not mixed with JSON) and double maintenance awareness. Self-contained single class like `Z_UI2_JSON` — locals in class includes, standard exceptions, no separate artifacts.
+
+## Constraints & decisions
+
+| Decision | Value |
+|---|---|
+| Min SAP_BASIS | **7.57+** (modern ABAP: inline decls, string templates, constructor/table expressions) |
+| Parse model | **One scan of text → lightweight node tree → dual mapper.** Single tokenization pass; node tree is the parse product (needed for clean anchor/alias resolution). Not a two-pass YAML→JSON bridge. |
+| GENERATE | **Always optimized** (mirrors JSON2 Decision 12). No `GEN_OPTIMIZE`/`OPTIMIZE` param. Typed tables + directly-typed struct components, no `REF TO data` wrappers. Char-check type detection, no regex. |
+| Born modern | Never carry JSON legacy utilities (see API §Dropped). |
+| Exceptions | Reuse standard `CX_SY_CONVERSION_ERROR` (structural) + `CX_SY_MOVE_CAST_ERROR` (strict-mode type mismatch). No dedicated exception class. |
+| Perf | Establish-baseline only for v1. Config files are small; no shared hot path. Not a regression gate. |
+| Post-v1 | Validate & optimize scanner/parser against real config examples. |
+
+## v1 scope
+
+**Read features (all in v1):**
+- Block mappings & sequences (core)
+- Plain / single-quoted / double-quoted scalars
+- `#` comments, single `---` doc start / `...` end
+- Flow style `{a: 1}` / `[x, y]` (YAML 1.2 ⊇ JSON; inline char cursor)
+- Block scalars `|` and `>` with chomping (`-`/`+`/clip) and folding
+- Anchors `&name` / aliases `*name` (resolve transparently on read)
+
+**Data directions:** typed (`SERIALIZE`/`DESERIALIZE`) **and** untyped (`GENERATE`).
+
+**Write:** block style, quote-when-necessary. **Anchors NOT emitted in v1** (would need cycle detection + dedup heuristic) — documented limitation.
+
+**Out of v1 (documented as unsupported):** multiple documents in a stream, tags (`!!str`, `!Custom` — RTTI target provides type instead), complex/mapping keys (`?`), anchor emission on write.
+
+## Architecture
+
+```
+READ:  yaml text ─▶ lcl_scanner ─▶ lcl_parser ─▶ node tree ─▶ mapper ─▶ ABAP data
+                   (lines,indent,   (indent stack, (+anchor tbl)  ├ lcl_typed_mapper (RTTI)  → DESERIALIZE
+                    comments,        flow cursor,                  └ lcl_gen_mapper (optimized) → GENERATE
+                    blk-scalar hdr)  anchors)
+
+WRITE: ABAP data + RTTI ─▶ lcl_emitter ─▶ yaml text  (block style, quote-when-needed)
+```
+
+Six focused, independently-testable units (all locals inside the class):
+
+1. **`lcl_scanner`** — text → flat stream of logical lines: `indent` (leading spaces), comment-stripped `content`, flags `doc_marker` / `block_scalar_header`. Drops comments & blank lines *except* inside block scalars. **Tab in indentation → fatal.**
+2. **`lcl_parser`** — indent stack drives nesting; first child line decides mapping (`key:`) vs sequence (`- `). Flow collections & quoted scalars scanned inline via a char cursor (never touch indent stack). Block scalars grab more-indented following lines, apply chomping/folding. `&anchor` registers node ref in anchor table after parse; `*alias` splices the referenced node. Output: node tree.
+3. **Node tree** — 3 node kinds: scalar, sequence, mapping (`kind`, `value`, children). Minimal intermediate.
+4. **`lcl_typed_mapper`** — walks nodes against `CL_ABAP_TYPEDESCR`, honoring name_mappings + pretty_name inverse. DESERIALIZE path.
+5. **`lcl_gen_mapper`** — infers types (uniform seq → typed table; mapping → typed components), builds always-optimized `REF TO DATA`. GENERATE path.
+6. **`lcl_emitter`** — RTTI walk → block YAML. Quote-when-necessary: values with `:`, `#`, leading `-`, `[`/`{`, boolean-like strings, empty (`''`). Indent by depth.
+
+`Z_UI2_YAML` public class is a thin facade over the locals, mirroring `Z_UI2_JSON`'s public shape.
+
+## Public API
+
+```abap
+" ── READ ──
+DESERIALIZE( importing yaml type string / yamlx type xstring optional
+                       pretty_name   type pretty_name_mode default none
+                       name_mappings type name_mappings optional
+             changing  data type data )                    " typed, RTTI target
+
+GENERATE( importing yaml type string ...                   " untyped → always-optimized REF TO DATA
+          returning value(rr_data) type ref to data )
+
+" ── WRITE ──
+SERIALIZE( importing data type data
+                     name          type string optional    " root key, optional
+                     compress      type bool default false " skip initial fields
+                     pretty_name   type pretty_name_mode default none
+                     name_mappings type name_mappings optional
+           returning value(r_yaml) type string )
+```
+
+Dual static + `_INT` instance pattern; advanced switches on `CONSTRUCTOR` only (narrow static API rule, carried from JSON).
+
+**Kept from JSON (1:1 concepts):** dual static/`_INT` API; `PRETTY_NAME` modes + `PRETTY_NAME`/`PRETTY_NAME_EX` override hooks; `NAME_MAPPINGS`; `COMPRESS`; `STRICT_MODE` (constructor) + `CX_SY_MOVE_CAST_ERROR` contract; `ASSOC_ARRAYS`; scalar formatting (dates / timestamps / numbers / booleans).
+
+**Dropped (JSON legacy — never added):** `DUMP` (use SERIALIZE), `RAW_TO_STRING` / `STRING_TO_RAW` / `XSTRING_TO_STRING` / `STRING_TO_XSTRING`, `ESCAPE` / `UNESCAPE`, `BOOL_TO_TRIBOOL` / `TRIBOOL_TO_BOOL`, `GET_INDENT`, `GEN_OPTIMIZE` / `OPTIMIZE`, `JSONX_CP`, `FORMAT_OUTPUT` (YAML always formatted).
+
+**Added (YAML-only, CONSTRUCTOR unless noted):**
+
+| Param | Where | Purpose | Default |
+|---|---|---|---|
+| `INDENT` | CONSTRUCTOR | spaces per level | 2 |
+| `EMIT_DOC_MARKERS` | CONSTRUCTOR | emit leading `---` | off |
+| `QUOTE_STYLE` | CONSTRUCTOR | plain-preferred / always-double (emit) | plain |
+| `FLOW_THRESHOLD` | CONSTRUCTOR | inline short collections as flow | off (always block) |
+| `HEADER_COMMENT` | SERIALIZE | optional `#` banner line(s) at top | — |
+
+## Data flow (read)
+
+- **Scanner → Parser handoff:** scanner emits logical lines with indent + flags. Parser uses an **indent stack**:
+  - Deeper indent → open child collection; first child line decides mapping vs sequence.
+  - Equal indent → sibling. Shallower → pop until match; landing between levels → fatal.
+  - `key:` with nothing after → value is nested block below, or null (`~`/empty) if none.
+  - `- ` → sequence item; `- key: val` → item is a mapping (indent continues past dash).
+  - Flow `{}`/`[]` & quoted scalars → inline char cursor, never touch indent stack.
+  - Block scalars → grab following more-indented lines, apply chomping (`-` strip / `+` keep / clip default) + folding (`>`), emit one scalar node.
+  - `&anchor` → store `name → node ref` after node parses; `*alias` → splice referenced node.
+- **Emit:** RTTI walk, one node per component, quote-when-necessary, indent by depth.
+
+## Error handling
+
+- **Default (lenient):** best-effort. Unmappable scalar → target stays initial. Unknown mapping key → skipped. Duplicate key → last wins.
+- **`STRICT_MODE = abap_true`** → `DESERIALIZE_INT` raises `CX_SY_MOVE_CAST_ERROR` with path (`$.server.ports[0]`). No success/failure boolean (JSON rule).
+- **Structural YAML errors** (tab in indent, bad dedent, unterminated quote/flow, alias to undefined anchor, block-scalar indent violation) → **always fatal in both modes**, `CX_SY_CONVERSION_ERROR`, message carries line number. This is the one divergence from JSON: indentation makes structural errors real and they must fail loudly even when lenient.
+
+## Testing
+
+`z_ui2_yaml.clas.testclasses.abap`, run via `RunAbapUnit`. By unit:
+
+- **Scanner:** indent counting, comment stripping, tab rejection, doc markers, block-scalar header detection.
+- **Parser/read:** per-feature fixtures — block mapping/sequence, nested mix, `- key:` items, plain/single/double scalars, flow `{}`/`[]`, block scalars `|`/`>` all chomping modes, anchors→aliases shared content, null, interleaved comments.
+- **Typed vs GENERATE:** same YAML into known structure vs GENERATE; assert optimized output (typed tables, no `REF TO data`).
+- **Emit:** quote-when-necessary matrix (`:`, `#`, leading `-`, `[`, boolean-like, empty), indent widths, name_mappings + pretty_name, header comment.
+- **Round-trip:** emit → read → assert-equal on representative structures (strongest config check).
+- **Strict vs lenient:** structural fatal in both; type mismatch fatal only in strict; path in message.
+- **Real-world fixtures:** a few actual config shapes (CI-file-ish, app-config, list-of-servers) as reality anchor.
+
+**Performance:** `Z_UI2_YAML_PERF` in the same style as `Z_UI2_JSON_PERF` (static `run()` → typed results; testclass `fail()` with formatted numbers). **Baseline-establishment only for v1** — not a regression gate.
+
+## Post-v1 (deferred, on demand)
+
+- Anchor **emission** on write (cycle detection + dedup).
+- Multiple documents in a stream.
+- Tags (`!!str`, custom).
+- Scanner/parser validation & optimization against real-world config corpus.
+
+## Source file layout (abapGit)
+
+- `src/z_ui2_yaml.clas.abap` — main class + local class definitions
+- `src/z_ui2_yaml.clas.locals_imp.abap` — `lcl_scanner` / `lcl_parser` / mappers / `lcl_emitter` implementations
+- `src/z_ui2_yaml.clas.testclasses.abap` — unit tests
+- `src/z_ui2_yaml.clas.xml` — abapGit metadata (generated)
+- `src/z_ui2_yaml_perf.clas.abap` (+ testclasses) — performance harness
+- `docs/feature-requests-yaml.md` — **own** feature tracking, separate from JSON

--- a/docs/superpowers/specs/2026-07-31-z_ui2_yaml-deferrals-design.md
+++ b/docs/superpowers/specs/2026-07-31-z_ui2_yaml-deferrals-design.md
@@ -1,0 +1,72 @@
+# Z_UI2_YAML — Deferral Resolution Spec (Phase A)
+
+**Date:** 2026-07-31
+**Status:** Design approved — ready for implementation plan
+**Branch:** feat/z_ui2_yaml (continues the v1 work)
+**Related:** [2026-07-30-z_ui2_yaml-design.md](2026-07-30-z_ui2_yaml-design.md), [docs/feature-requests-yaml.md](../../../docs/feature-requests-yaml.md)
+
+## Purpose
+
+Resolve the seven documented v1 deferrals: BUILD three, DECLINE four (three as logged decisions + one as a doc-only decision). Keep the class lean before the Phase B optimization pass.
+
+## Build set
+
+### #1 — camelCase/PascalCase inverse on DESERIALIZE
+
+**Problem:** `SERIALIZE(pretty_name = camel_case)` emits `myField`, but DESERIALIZE only does a case-insensitive uppercase match, so `myField` won't map back to component `MY_FIELD`. Round-trip is asymmetric.
+
+**Fix:** In `lcl_typed_mapper=>map` (struct branch), when the existing name_mappings + case-insensitive-uppercase match fails to find a component, apply the **inverse** pretty_name transform to the YAML key and retry:
+- `camel_case` / `extended`: `myField` → `MY_FIELD` (insert `_` before each interior uppercase letter, upper-case all).
+- `pascal_case`: `MyField` → `MY_FIELD` (same, first letter also boundary).
+- `low_case`: already covered by case-insensitive match.
+- `none`: no transform (current behavior).
+
+**Perf-neutrality:** guard the inverse transform behind `pretty_name <> pretty_mode-none` at the top of component resolution — the default path adds zero per-field cost. The transform only runs when a direct match already failed AND a non-none pretty_name is active.
+
+**Tests:** camelCase round-trip (`SERIALIZE(camel)` → `DESERIALIZE(camel)` equals original) into a struct with a multi-word component; PascalCase likewise.
+
+### #4 — Multi-document streams: `GENERATE_ALL` + `DESERIALIZE_ALL`
+
+**Problem:** `---`-separated multi-doc YAML (K8s-style) yields only the first document.
+
+**Design:** The scanner already flags `doc_marker` (`...`) and drops `---`. Change: the scanner (or a thin splitter above the parser) must expose document boundaries. Simplest approach that preserves existing behavior — a helper `split_documents( lines ) RETURNING tt_line_blocks` that partitions the `ty_lines` stream at `---` markers into N sub-streams (a `---` starts a new document; `...` ends the current one). Then:
+
+- `CLASS-METHODS generate_all IMPORTING yaml TYPE string RETURNING VALUE(rt_data) TYPE ref_tab` where `ref_tab` = `STANDARD TABLE OF REF TO data` — one entry per document, each built via the existing `lcl_gen_mapper=>generate` on that document's node tree. Untyped, heterogeneous doc shapes OK. Structural errors propagate (consistent with `generate`).
+- `METHODS deserialize_all IMPORTING yaml TYPE string CHANGING results TYPE STANDARD TABLE` (+ static wrapper) — `results` is a caller-provided table of a uniform line type; for each document, create a line workarea, map via the existing `lcl_typed_mapper=>map`, APPEND. Assumes all docs share the table's line type (documented). Static wrapper mirrors `deserialize`'s narrow signature (yaml + results + pretty_name + name_mappings).
+
+**Backward compatibility:** existing `DESERIALIZE` / `GENERATE` unchanged — they process the **first** document only (current behavior; the splitter's first block). Both new methods are thin loops over the existing single-doc path — no new parsing logic, only stream partitioning + iteration.
+
+**Scanner impact:** currently `---` lines are dropped. The splitter needs to SEE them. Options: (a) scanner keeps `---` as a flagged boundary line rather than dropping it, and single-doc `parse` ignores a leading boundary; (b) a separate `scan_documents` that returns `tt_line_blocks`. Prefer (a) minimal: add a `doc_start` flag to `ty_line`, keep the line, and have single-doc `parse` skip a leading `doc_start`. `split_documents` partitions on `doc_start`/`doc_marker`.
+
+**`ref_tab` type:** reuse a `TYPES ref_tab TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY` on the public class (mirrors Z_UI2_JSON's `ref_tab`).
+
+**Tests:** GENERATE_ALL on a 3-doc stream → 3 refs, spot-check field in doc 2 and 3; DESERIALIZE_ALL of a 2-doc uniform stream into a typed table → 2 rows with correct values; single-doc input through GENERATE_ALL → 1 entry (degenerate case); existing DESERIALIZE on multi-doc input → still returns doc 1 only (backward-compat guard).
+
+### #3 — Block-header anchors on read (`key: &a |`)
+
+**Problem:** The scanner resolves block scalars and sets `blk_value` + `blk_scalar_hd`, bypassing `value_or_block` where anchor registration lives — so an anchor on a block-scalar header line is lost.
+
+**Fix:** In the scanner's block-header handling, detect and strip a leading `&name` from the header remainder (the text between `key:` and the `|`/`>` indicator), and stash the anchor name on the line (new `ty_line` field `blk_anchor TYPE string`, or reuse a general mechanism). In `parse_mapping`, when consuming a `blk_scalar_hd` line, after building the scalar node, if `blk_anchor` is set, register it in the anchor table (same registration path Task 7 uses). Alias resolution is unchanged (aliases to a block-anchored node already work once registered).
+
+**Tests:** `k: &a |` + body, then `k2: *a` → both resolve to the same block-scalar value; the anchored node is registered.
+
+## Decline set (log as decisions, no code)
+
+Each gets a durable entry in CLAUDE.md "API Design Decisions", and feature-requests-yaml.md moves them to a "Declined" section pointing at CLAUDE.md.
+
+- **#2 Anchor emission on write** — Declined. Requires cycle detection + a dedup heuristic to decide what to anchor; a config *producer* emits fully-expanded YAML, which is more readable for humans editing config. Read-side anchor support stays. Reopen only on concrete demand.
+- **#5 Tags (`!!str`, `!<uri>`)** — Declined. Rare in hand-written config; the target ABAP type already determines interpretation (RTTI on deserialize, char-check on generate), so a tag would be redundant or conflicting. Current silent-ignore stays.
+- **#6 Explicit block-scalar indent indicator (`|2`, `>4`)** — Declined. Auto-detection from the first non-blank body line's indent covers essentially all real content; the explicit form exists for rare ambiguous cases (leading-space content) that config rarely needs. Reopen on demand.
+- **#7 Default key case** — Keep `pretty_mode-none` (uppercase passthrough) as the default, for consistency with Z_UI2_JSON's established convention. Changing the default would be a breaking change for existing callers. Resolution is **documentation**: yaml.md gets a prominent "Producing conventional lowercase config keys" note steering users to `pretty_name = pretty_mode-low_case`. No code change.
+
+## Constraints (unchanged from v1)
+
+- SAP_BASIS 7.57+, modern ABAP, self-contained (no Z_UI2_JSON dependency), PRISTINE test output.
+- Structural errors → `cx_sy_conversion_no_number`; strict type mismatch → `cx_sy_move_cast_error`.
+- New feature work perf-neutral when the relevant option is unused (guard at top-level, not per-node).
+- Static API stays narrow; `DESERIALIZE_ALL`/`GENERATE_ALL` are new top-level methods (not switches on existing ones).
+- Tests run in-system via `RunAbapUnit` on ER1; commit to git after each green task; mirror ER1 source into `src/`.
+
+## Out of scope
+
+Phase B (full class review + reuse/simplicity/maintainability optimization) is a separate effort after Phase A merges clean.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -105,6 +105,27 @@ z_ui2_yaml=>deserialize(
 
 Key matching is **case-insensitive**: YAML key `host` matches ABAP component `HOST`.
 
+### Pretty-name mapping on DESERIALIZE
+
+As of v1.1, `pretty_name` inverse mapping (camelCase/PascalCase → ABAP field names) is now supported during deserialization:
+
+```abap
+TYPES: BEGIN OF ty,
+         first_name TYPE string,
+         last_name  TYPE string,
+       END OF ty.
+DATA person TYPE ty.
+
+" YAML with camelCase keys:
+z_ui2_yaml=>deserialize(
+  EXPORTING yaml          = |firstName: John\nlastName: Doe|
+            pretty_name   = z_ui2_yaml=>pretty_mode-camel_case
+  CHANGING  data          = person ).
+" person-first_name = 'John', person-last_name = 'Doe'
+```
+
+**Caveat:** ABAP names with consecutive interior capitals (e.g. `MY_URL`) do not round-trip: MY_URL → myURL → inverse MY_U_R_L (no match). This is an inherent limitation of inverting a lossy forward transform. For such fields, use explicit `name_mappings` instead.
+
 ### Nested structures and sequences
 
 ```abap
@@ -172,14 +193,80 @@ Component names are always **UPPERCASE** (sanitized: non-alphanumeric → `_`, m
 
 ---
 
-## Limitations (v1)
+## Multi-Document Streams (v1.1)
 
-The following features are **not supported** in v1:
+For YAML inputs with multiple `---` document separators, use `GENERATE_ALL` and `DESERIALIZE_ALL`:
 
-- **YAML key case on DESERIALIZE** — `pretty_name` inverse (camelCase→field) is not applied during deserialization; key matching is always case-insensitive uppercase comparison.
-- **Anchor emission** — writing `&anchor` / `*alias` references in serialized output is not supported. Anchors are fully supported on **read**.
-- **Multi-document streams** — `---` document separators are silently skipped; only the first document is processed.
-- **Tags** — `!!str`, `!!int`, `!<uri>` tags are ignored during parse.
+### GENERATE_ALL (schema-free, all documents)
+
+Returns a typed table of `REF TO data`, one entry per document:
+
+```abap
+DATA yaml_multi TYPE string.
+yaml_multi = |---\nhost: server1\nport: 8080\n---\nhost: server2\nport: 9090|.
+
+DATA(docs) = z_ui2_yaml=>generate_all( yaml_multi ).
+" docs is a table with 2 rows; each row->* is an inferred structure
+LOOP AT docs INTO DATA(ref_doc).
+  FIELD-SYMBOLS <s> TYPE any.
+  ASSIGN ref_doc->* TO <s>.
+  FIELD-SYMBOLS <host> TYPE any.
+  ASSIGN COMPONENT `HOST` OF STRUCTURE <s> TO <host>.
+  WRITE <host>.  " server1, then server2
+ENDLOOP.
+```
+
+### DESERIALIZE_ALL (typed table, all documents)
+
+Fills a caller-provided typed internal table, one row per document (all docs assumed same shape):
+
+```abap
+TYPES: BEGIN OF ty_srv, host TYPE string, port TYPE i, END OF ty_srv.
+DATA servers TYPE STANDARD TABLE OF ty_srv WITH DEFAULT KEY.
+
+z_ui2_yaml=>deserialize_all(
+  EXPORTING yaml = |---\nhost: db1\nport: 5432\n---\nhost: db2\nport: 5433|
+  CHANGING  data = servers ).
+" servers has 2 rows: (db1, 5432), (db2, 5433)
+```
+
+**Note:** Existing `DESERIALIZE` and `GENERATE` (without `_ALL` suffix) remain single-document-only for backward compatibility. Use the `_ALL` variants for multi-document processing.
+
+---
+
+## Limitations & Design Notes
+
+### Producing Lowercase Config Keys
+
+**By default**, `SERIALIZE` emits ABAP component names in UPPERCASE (via `pretty_mode-none`):
+```abap
+" Default output:
+DATA(yaml) = z_ui2_yaml=>serialize( servers ).
+" Result: HOST, PORT, ENABLED (all caps)
+```
+
+To produce conventional **lowercase** config keys, always pass `pretty_name`:
+```abap
+" Lowercase output:
+DATA(yaml) = z_ui2_yaml=>serialize(
+  data        = servers
+  pretty_name = z_ui2_yaml=>pretty_mode-low_case ).
+" Result: host, port, enabled (lowercase)
+```
+
+This default choice preserves consistency with `Z_UI2_JSON` and avoids breaking existing callers. The lowercase pattern is the recommended standard for new YAML configs.
+
+### Unsupported v1 Features
+
+The following features are **declined** and will not be implemented:
+
+- **Anchor emission on write** — `&anchor` / `*alias` in serialized output. Anchors are fully supported on **read** (including block-header anchors). Reopen on concrete demand.
+- **YAML tags** — `!!str`, `!!int`, `!<uri>` tags are silently ignored on parse. The ABAP target type (via RTTI on DESERIALIZE, type inference on GENERATE) determines interpretation.
 - **Explicit block-scalar indent indicator** — `|2`, `>4` etc. are not supported; the indent column is auto-detected from body content.
-- **Block-header anchors** — `key: &a |` (anchor on a block scalar header line) is deferred.
-- **Default key case** — `pretty_mode-none` (the default) emits ABAP's UPPERCASE component names. Use `pretty_mode-low_case` to produce standard lowercase YAML.
+- **Consecutive-caps name round-trip** — ABAP names with interior caps (e.g. `MY_URL`) do not round-trip under camelCase/PascalCase inverse: MY_URL → myURL → inverse MY_U_R_L (no match). Use explicit `name_mappings` for such fields.
+
+### Supported v1 Features
+
+- **Anchors & aliases on read** — `&anchor` and `*alias` are fully processed, including block-header anchors (`key: &a |`).
+- **Multi-document streams** — Use `GENERATE_ALL` and `DESERIALIZE_ALL` for documents with `---` separators.
+- **Pretty-name inverse on DESERIALIZE** — camelCase/PascalCase keys now map to ABAP field names (with the consecutive-caps caveat above).

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -276,10 +276,12 @@ The following features are **declined** and will not be implemented:
 
 Captured via `Z_UI2_YAML_PERF=>run()` on ER1 (SAP_BASIS 7.57+), 1000 iterations each on a small nested config (a mapping with a 3-element list of `{host, port, enabled}` objects). Establish-baseline only — not a regression gate.
 
-| Scenario | µs / op |
-|----------|---------|
-| SERIALIZE small config | 174 |
-| DESERIALIZE small config | 624 |
-| GENERATE small config | 735 |
+| Scenario | µs / op | notes |
+|----------|---------|-------|
+| SERIALIZE small config | 172 | |
+| DESERIALIZE small config | 510 | optimized (-19% vs pre-opt 632) |
+| GENERATE small config | 648 | optimized (-13% vs pre-opt 749) |
+
+Pre-optimization numbers (2026-07-31): SERIALIZE 174 µs, DESERIALIZE 632 µs, GENERATE 749 µs.
 
 To refresh: run ABAP Unit on `Z_UI2_YAML_PERF` (the `baseline` method intentionally fails with the numbers in its message) or call `Z_UI2_YAML_PERF=>run()` directly.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -264,9 +264,22 @@ The following features are **declined** and will not be implemented:
 - **YAML tags** — `!!str`, `!!int`, `!<uri>` tags are silently ignored on parse. The ABAP target type (via RTTI on DESERIALIZE, type inference on GENERATE) determines interpretation.
 - **Explicit block-scalar indent indicator** — `|2`, `>4` etc. are not supported; the indent column is auto-detected from body content.
 - **Consecutive-caps name round-trip** — ABAP names with interior caps (e.g. `MY_URL`) do not round-trip under camelCase/PascalCase inverse: MY_URL → myURL → inverse MY_U_R_L (no match). Use explicit `name_mappings` for such fields.
+- **GENERATE of a heterogeneous sequence of structurally-different objects** — a uniform list of objects (all elements the same shape) generates a typed table correctly. A list mixing objects of *different* shapes falls back to a string table and silently drops the deep (struct/table) elements rather than dumping. Uniform lists (the common config case) and mixed *scalar* sequences are fully supported.
 
 ### Supported v1 Features
 
 - **Anchors & aliases on read** — `&anchor` and `*alias` are fully processed, including block-header anchors (`key: &a |`).
 - **Multi-document streams** — Use `GENERATE_ALL` and `DESERIALIZE_ALL` for documents with `---` separators.
 - **Pretty-name inverse on DESERIALIZE** — camelCase/PascalCase keys now map to ABAP field names (with the consecutive-caps caveat above).
+
+### Performance Baseline
+
+Captured via `Z_UI2_YAML_PERF=>run()` on ER1 (SAP_BASIS 7.57+), 1000 iterations each on a small nested config (a mapping with a 3-element list of `{host, port, enabled}` objects). Establish-baseline only — not a regression gate.
+
+| Scenario | µs / op |
+|----------|---------|
+| SERIALIZE small config | 174 |
+| DESERIALIZE small config | 624 |
+| GENERATE small config | 735 |
+
+To refresh: run ABAP Unit on `Z_UI2_YAML_PERF` (the `baseline` method intentionally fails with the numbers in its message) or call `Z_UI2_YAML_PERF=>run()` directly.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -1,0 +1,176 @@
+# Z_UI2_YAML — Usage Reference
+
+`Z_UI2_YAML` is a self-contained YAML 1.2 config reader/writer for ABAP.
+Requires SAP_BASIS 7.57+. No external dependencies.
+
+---
+
+## API Overview
+
+Three static entry points mirror the JSON class pattern:
+
+| Method | Direction |
+|---|---|
+| `Z_UI2_YAML=>SERIALIZE( data )` | ABAP → YAML string |
+| `Z_UI2_YAML=>DESERIALIZE( yaml = … CHANGING data = … )` | YAML string → ABAP |
+| `Z_UI2_YAML=>GENERATE( yaml )` | YAML string → `REF TO data` (schema-free) |
+
+Instance methods `SERIALIZE_INT` / `DESERIALIZE_INT` are available when you create an instance with custom constructor options and want to reuse it.
+
+---
+
+## SERIALIZE
+
+```abap
+TYPES: BEGIN OF ty_server,
+         host    TYPE string,
+         port    TYPE i,
+         enabled TYPE abap_bool,
+       END OF ty_server.
+DATA servers TYPE STANDARD TABLE OF ty_server WITH DEFAULT KEY.
+servers = VALUE #( ( host = `db1` port = 5432 enabled = abap_true )
+                   ( host = `db2` port = 5432 enabled = abap_false ) ).
+
+" Default: ABAP component names emitted as UPPERCASE
+DATA(yaml_upper) = z_ui2_yaml=>serialize( servers ).
+" Result:
+" - HOST: db1
+"   PORT: 5432
+"   ENABLED: true
+
+" Use pretty_name = pretty_mode-low_case for lowercase keys
+DATA(yaml_lower) = z_ui2_yaml=>serialize(
+  data        = servers
+  pretty_name = z_ui2_yaml=>pretty_mode-low_case ).
+" Result:
+" - host: db1
+"   port: 5432
+"   enabled: true
+```
+
+> **Key case note:** The default `pretty_mode-none` preserves ABAP's UPPERCASE component names.
+> Use `pretty_name = pretty_mode-low_case` (or `camel_case` / `pascal_case`) to produce
+> lowercase keys compatible with standard YAML configs.
+
+### Static parameters
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `data` | — | Any ABAP data (structure, table, elementary) |
+| `pretty_name` | `pretty_mode-none` (UPPERCASE) | Key case: `low_case`, `camel_case`, `pascal_case` |
+| `name_mappings` | — | Explicit ABAP→YAML key overrides |
+| `compress` | `abap_false` | Skip initial/empty fields |
+| `header_comment` | — | Prepended as `# …` comment lines |
+
+### Constructor-only options (use instance API for these)
+
+```abap
+DATA(o) = NEW z_ui2_yaml(
+  indent           = 4           " indentation spaces (default 2)
+  emit_doc_markers = abap_true   " prepend --- / append ...
+  quote_style      = 'D'         " always double-quote strings ('P' = smart, default)
+  flow_threshold   = 3           " emit sequences with ≤3 items as flow [a, b, c]
+).
+DATA(yaml) = o->serialize_int( my_data ).
+```
+
+### Bool fields
+
+`TYPE abap_bool` fields round-trip as `true` / `false`:
+
+```abap
+TYPES: BEGIN OF ty, enabled TYPE abap_bool, END OF ty.
+DATA(in) = VALUE ty( enabled = abap_true ).
+DATA(yaml) = z_ui2_yaml=>serialize( data = in pretty_name = z_ui2_yaml=>pretty_mode-low_case ).
+" → "enabled: true"
+```
+
+---
+
+## DESERIALIZE
+
+```abap
+TYPES: BEGIN OF ty_cfg,
+         name     TYPE string,
+         enabled  TYPE abap_bool,
+         replicas TYPE i,
+       END OF ty_cfg.
+DATA cfg TYPE ty_cfg.
+
+z_ui2_yaml=>deserialize(
+  EXPORTING yaml = |name: web\nenabled: true\nreplicas: 3|
+  CHANGING  data = cfg ).
+" cfg-name = 'web', cfg-enabled = 'X', cfg-replicas = 3
+```
+
+Key matching is **case-insensitive**: YAML key `host` matches ABAP component `HOST`.
+
+### Nested structures and sequences
+
+```abap
+TYPES: BEGIN OF ty_s, host TYPE string, port TYPE i, END OF ty_s.
+TYPES: BEGIN OF ty_w,
+         servers TYPE STANDARD TABLE OF ty_s WITH DEFAULT KEY,
+       END OF ty_w.
+DATA w TYPE ty_w.
+
+z_ui2_yaml=>deserialize(
+  EXPORTING yaml = |servers:\n  - host: a\n    port: 1\n  - host: b\n    port: 2|
+  CHANGING  data = w ).
+" lines( w-servers ) = 2,  w-servers[ 2 ]-host = 'b'
+```
+
+### Strict mode (instance API)
+
+```abap
+DATA(o) = NEW z_ui2_yaml( strict_mode = abap_true ).
+TRY.
+    o->deserialize_int( EXPORTING yaml = |port: notanumber| CHANGING data = out ).
+  CATCH cx_sy_move_cast_error.
+    " field-level type mismatch raised here
+ENDTRY.
+```
+
+The static `DESERIALIZE` is always lenient — type errors leave the field initial.
+
+### name_mappings
+
+```abap
+DATA nm TYPE z_ui2_yaml=>name_mappings.
+INSERT VALUE #( abap = `MY_FIELD` yaml = `myField` ) INTO TABLE nm.
+z_ui2_yaml=>deserialize(
+  EXPORTING yaml          = |myField: hello|
+            name_mappings = nm
+  CHANGING  data          = my_struct ).
+```
+
+---
+
+## GENERATE (schema-free)
+
+Returns a `REF TO data` — type is inferred from YAML values (`true`/`false` → `abap_bool`, integers → `i`, decimals → `decfloat34`, dates `YYYY-MM-DD` → `d`, everything else → `string`).
+
+```abap
+DATA(r) = z_ui2_yaml=>generate( |host: db1\nport: 5432| ).
+FIELD-SYMBOLS <s> TYPE any.
+ASSIGN r->* TO <s>.
+FIELD-SYMBOLS <f> TYPE any.
+ASSIGN COMPONENT `HOST` OF STRUCTURE <s> TO <f>.
+WRITE <f>.  " db1
+```
+
+Component names are always **UPPERCASE** (sanitized: non-alphanumeric → `_`, max 30 chars).
+
+---
+
+## Limitations (v1)
+
+The following features are **not supported** in v1:
+
+- **YAML key case on DESERIALIZE** — `pretty_name` inverse (camelCase→field) is not applied during deserialization; key matching is always case-insensitive uppercase comparison.
+- **Anchor emission** — writing `&anchor` / `*alias` references in serialized output is not supported. Anchors are fully supported on **read**.
+- **Multi-document streams** — `---` document separators are silently skipped; only the first document is processed.
+- **Tags** — `!!str`, `!!int`, `!<uri>` tags are ignored during parse.
+- **Explicit block-scalar indent indicator** — `|2`, `>4` etc. are not supported; the indent column is auto-detected from body content.
+- **Block-header anchors** — `key: &a |` (anchor on a block scalar header line) is deferred.
+- **Default key case** — `pretty_mode-none` (the default) emits ABAP's UPPERCASE component names. Use `pretty_mode-low_case` to produce standard lowercase YAML.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -274,14 +274,42 @@ The following features are **declined** and will not be implemented:
 
 ### Performance Baseline
 
-Captured via `Z_UI2_YAML_PERF=>run()` on ER1 (SAP_BASIS 7.57+), 1000 iterations each on a small nested config (a mapping with a 3-element list of `{host, port, enabled}` objects). Establish-baseline only — not a regression gate.
+Captured via `Z_UI2_YAML_PERF=>run()` on ER1 (SAP_BASIS 7.57+). Small scenarios: 1000 iterations on a 3-element config. Large scenarios: wall-clock single op (or 2-3 iterations) on synthetic flat sequences of `{host, port, enabled}` rows.
+
+#### Small config (1000 rows, 1000× iterations)
 
 | Scenario | µs / op | notes |
 |----------|---------|-------|
 | SERIALIZE small config | 172 | |
-| DESERIALIZE small config | 510 | optimized (-19% vs pre-opt 632) |
-| GENERATE small config | 648 | optimized (-13% vs pre-opt 749) |
+| DESERIALIZE small config | 511 | |
+| GENERATE small config | 542 | optimized (-17% vs pre-opt 652 via struct-type cache, Opt D) |
 
-Pre-optimization numbers (2026-07-31): SERIALIZE 174 µs, DESERIALIZE 632 µs, GENERATE 749 µs.
+Pre-optimization numbers (2026-07-31): SERIALIZE 181 µs, DESERIALIZE 510 µs, GENERATE 652 µs.
+
+#### Large scenarios — Deserialize (flat 3-field rows, typed target table)
+
+| Scenario | Before Opt D | After Opt D | delta |
+|----------|-------------|-------------|-------|
+| Deserialize 10k rows | 1,197k µs | 1,195k µs | ~0% (unaffected — opt D is gen_mapper only) |
+| Deserialize 100k rows | 11,984k µs | 11,974k µs | ~0% |
+
+DESERIALIZE is dominated by: scanner (SPLIT + line processing ~300k lines) + parser (~400k `lcl_node_ref` heap allocations + tree building) + typed mapper (trivial component assignment). Mapper-side caches (A: component-name hash) show no gain at any scale because the per-row component scan over 3 fields is O(3) — identical cost to a hash lookup. The floor is parser/scanner, not mapper.
+
+#### Large scenarios — Generate (flat 3-field rows, schema-free)
+
+| Scenario | Before Opt D | After Opt D | delta |
+|----------|-------------|-------------|-------|
+| Generate 10k rows | 1,852k µs | 1,440k µs | **-22%** |
+| Generate 100k rows | 18,539k µs | 14,271k µs | **-23%** |
+
+GENERATE per-row cost dropped from ~185 µs to ~143 µs by caching the struct type descriptor (`cl_abap_structdescr=>create` was called 100k times for identical 3-field shapes; now called once, result cached by component-name+type fingerprint). Remaining cost per row: ~40 µs `cl_abap_tabledescr=>create` (called once at sequence level, outside the row loop) + ~100 µs per-row work (300k `detect_scalar_type` calls, 300k `describe_by_data_ref` calls, 100k `CREATE DATA` for row instances, 100k `INSERT INTO TABLE`).
+
+**Optimizations tested but not kept:**
+- **A (struct component-match cache in mapper):** No gain at any scale. 3-field row means O(3) linear scan = O(1) hash overhead — a wash.
+- **B (workarea reuse, CREATE DATA hoisted out of loop):** -1.7% on deserialize-100k — noise. ABAP's `INSERT <wa> INTO TABLE` copies by value regardless; the CREATE DATA itself is not the bottleneck.
+- **C (inline `detect_scalar_type` to avoid method calls):** -0.8% on generate-100k — the work inside the method (string scans) dominates; call overhead (~1-3 µs × 300k ≈ 0.3-0.9s) was measured and confirmed immaterial.
+- **E (hoist `describe_by_data` out of loops):** Not applicable — already called once per recursive invocation, not per-child.
+- **F (buffer `&&` string concatenation):** No hot-path `&&` loop identified beyond the 3-field fingerprint build in Opt D (already included).
+- **G (node-tree allocation):** 400k `NEW lcl_node_ref()` per 100k-row deserialize confirmed as a structural floor (~30% of deserialize cost). Not addressable without a non-tree-based parser design. Reported as a ceiling finding.
 
 To refresh: run ABAP Unit on `Z_UI2_YAML_PERF` (the `baseline` method intentionally fails with the numbers in its message) or call `Z_UI2_YAML_PERF=>run()` directly.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -114,10 +114,17 @@ TYPES: BEGIN OF ty_w,
        END OF ty_w.
 DATA w TYPE ty_w.
 
+" Indented-style sequences (items 2 spaces deeper than key):
 z_ui2_yaml=>deserialize(
   EXPORTING yaml = |servers:\n  - host: a\n    port: 1\n  - host: b\n    port: 2|
   CHANGING  data = w ).
-" lines( w-servers ) = 2,  w-servers[ 2 ]-host = 'b'
+
+" Flush-style sequences (items at same indent as key):
+z_ui2_yaml=>deserialize(
+  EXPORTING yaml = |servers:\n- host: a\n  port: 1\n- host: b\n    port: 2|
+  CHANGING  data = w ).
+
+" Both forms produce: lines( w-servers ) = 2,  w-servers[ 2 ]-host = 'b'
 ```
 
 ### Strict mode (instance API)
@@ -149,6 +156,8 @@ z_ui2_yaml=>deserialize(
 ## GENERATE (schema-free)
 
 Returns a `REF TO data` — type is inferred from YAML values (`true`/`false` → `abap_bool`, integers → `i`, decimals → `decfloat34`, dates `YYYY-MM-DD` → `d`, everything else → `string`).
+
+Like `DESERIALIZE`, `GENERATE` raises `CX_SY_CONVERSION_ERROR` on structurally invalid YAML (e.g. tabs in indentation, bad nesting). Callers should handle it if the input is untrusted.
 
 ```abap
 DATA(r) = z_ui2_yaml=>generate( |host: db1\nport: 5432| ).

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -45,6 +45,10 @@ CLASS z_ui2_yaml DEFINITION
                 name_mappings TYPE name_mappings    OPTIONAL
       CHANGING  data          TYPE data.
 
+    CLASS-METHODS generate
+      IMPORTING yaml           TYPE string
+      RETURNING VALUE(rr_data) TYPE REF TO data.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
     DATA mv_pretty_name      TYPE pretty_name_mode.
@@ -96,6 +100,15 @@ CLASS z_ui2_yaml IMPLEMENTATION.
                             CHANGING  data  = data ).
       CATCH cx_sy_move_cast_error.
         " static API is lenient — strict_mode defaults false, so unreachable by design
+    ENDTRY.
+  ENDMETHOD.
+
+  METHOD generate.
+    TRY.
+        DATA(root) = lcl_parser=>parse( lcl_scanner=>scan( yaml ) ).
+        rr_data = lcl_gen_mapper=>generate( root ).
+      CATCH cx_sy_conversion_error.
+        " parse error — return initial (null ref)
     ENDTRY.
   ENDMETHOD.
 

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -22,11 +22,81 @@ CLASS z_ui2_yaml DEFINITION
 
     CONSTANTS version TYPE i VALUE 1 ##NO_TEXT.
 
-    " methods added in Tasks 8-11
+    METHODS constructor
+      IMPORTING pretty_name      TYPE pretty_name_mode DEFAULT pretty_mode-none
+                name_mappings    TYPE name_mappings    OPTIONAL
+                strict_mode      TYPE abap_bool        DEFAULT abap_false
+                assoc_arrays     TYPE abap_bool        DEFAULT abap_false
+                indent           TYPE i                OPTIONAL
+                emit_doc_markers TYPE abap_bool        DEFAULT abap_false
+                quote_style      TYPE c                OPTIONAL
+                flow_threshold   TYPE i                OPTIONAL.
+
+    METHODS deserialize_int
+      IMPORTING yaml  TYPE string  OPTIONAL
+                yamlx TYPE xstring OPTIONAL
+      CHANGING  data  TYPE data
+      RAISING   cx_sy_move_cast_error.
+
+    CLASS-METHODS deserialize
+      IMPORTING yaml          TYPE string           OPTIONAL
+                yamlx         TYPE xstring          OPTIONAL
+                pretty_name   TYPE pretty_name_mode DEFAULT pretty_mode-none
+                name_mappings TYPE name_mappings    OPTIONAL
+      CHANGING  data          TYPE data.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
+    DATA mv_pretty_name      TYPE pretty_name_mode.
+    DATA mt_name_mappings    TYPE name_mappings.
+    DATA mv_strict           TYPE abap_bool.
+    DATA mv_assoc_arrays     TYPE abap_bool.
+    DATA mv_indent           TYPE i.
+    DATA mv_emit_doc_markers TYPE abap_bool.
+    DATA mv_quote_style      TYPE c.
+    DATA mv_flow_threshold   TYPE i.
+
 ENDCLASS.
 
 CLASS z_ui2_yaml IMPLEMENTATION.
+
+  METHOD constructor.
+    mv_pretty_name      = pretty_name.
+    mt_name_mappings    = name_mappings.
+    mv_strict           = strict_mode.
+    mv_assoc_arrays     = assoc_arrays.
+    mv_indent           = COND #( WHEN indent IS SUPPLIED THEN indent ELSE 2 ).
+    mv_emit_doc_markers = emit_doc_markers.
+    mv_quote_style      = COND #( WHEN quote_style IS SUPPLIED THEN quote_style ELSE 'P' ).
+    mv_flow_threshold   = COND #( WHEN flow_threshold IS SUPPLIED THEN flow_threshold ELSE 0 ).
+  ENDMETHOD.
+
+  METHOD deserialize_int.
+    DATA lv_yaml TYPE string.
+    IF yamlx IS SUPPLIED AND yamlx IS NOT INITIAL.
+      lv_yaml = cl_abap_codepage=>convert_from( source   = yamlx
+                                                codepage = `UTF-8` ).
+    ELSE.
+      lv_yaml = yaml.
+    ENDIF.
+    DATA(root) = lcl_parser=>parse( lcl_scanner=>scan( lv_yaml ) ).
+    lcl_typed_mapper=>map( EXPORTING node          = root
+                                     pretty_name   = mv_pretty_name
+                                     name_mappings = mt_name_mappings
+                                     strict        = mv_strict
+                           CHANGING  data          = data ).
+  ENDMETHOD.
+
+  METHOD deserialize.
+    DATA(o) = NEW z_ui2_yaml( pretty_name   = pretty_name
+                              name_mappings = name_mappings ).
+    TRY.
+        o->deserialize_int( EXPORTING yaml  = yaml
+                                      yamlx = yamlx
+                            CHANGING  data  = data ).
+      CATCH cx_sy_move_cast_error.
+        " static API is lenient — strict_mode defaults false, so unreachable by design
+    ENDTRY.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -20,6 +20,12 @@ CLASS z_ui2_yaml DEFINITION
         extended    TYPE c LENGTH 1 VALUE 'Y',
       END OF pretty_mode.
 
+    CONSTANTS:
+      BEGIN OF quote_mode,
+        plain        TYPE c LENGTH 1 VALUE 'P',
+        always_double TYPE c LENGTH 1 VALUE 'D',
+      END OF quote_mode.
+
     TYPES ref_tab TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY.
 
     CONSTANTS version TYPE i VALUE 1 ##NO_TEXT.
@@ -84,7 +90,6 @@ CLASS z_ui2_yaml DEFINITION
       RETURNING VALUE(rt_data) TYPE ref_tab
       RAISING   cx_sy_conversion_error.
 
-  PROTECTED SECTION.
   PRIVATE SECTION.
     DATA mv_pretty_name      TYPE pretty_name_mode.
     DATA mt_name_mappings    TYPE name_mappings.
@@ -106,7 +111,7 @@ CLASS z_ui2_yaml IMPLEMENTATION.
     mv_assoc_arrays     = assoc_arrays.
     mv_indent           = COND #( WHEN indent IS SUPPLIED THEN indent ELSE 2 ).
     mv_emit_doc_markers = emit_doc_markers.
-    mv_quote_style      = COND #( WHEN quote_style IS SUPPLIED THEN quote_style ELSE 'P' ).
+    mv_quote_style      = COND #( WHEN quote_style IS SUPPLIED THEN quote_style ELSE quote_mode-plain ).
     mv_flow_threshold   = COND #( WHEN flow_threshold IS SUPPLIED THEN flow_threshold ELSE 0 ).
   ENDMETHOD.
 
@@ -128,7 +133,7 @@ CLASS z_ui2_yaml IMPLEMENTATION.
                                 pretty_name    = pretty_name
                                 name_mappings  = name_mappings
                                 indent_step    = 2
-                                quote_style    = 'P'
+                                quote_style    = quote_mode-plain
                                 emit_doc_markers = abap_false
                                 header_comment = header_comment ).
   ENDMETHOD.

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -61,7 +61,8 @@ CLASS z_ui2_yaml DEFINITION
 
     CLASS-METHODS generate
       IMPORTING yaml           TYPE string
-      RETURNING VALUE(rr_data) TYPE REF TO data.
+      RETURNING VALUE(rr_data) TYPE REF TO data
+      RAISING   cx_sy_conversion_error.
 
   PROTECTED SECTION.
   PRIVATE SECTION.
@@ -141,12 +142,8 @@ CLASS z_ui2_yaml IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD generate.
-    TRY.
-        DATA(root) = lcl_parser=>parse( lcl_scanner=>scan( yaml ) ).
-        rr_data = lcl_gen_mapper=>generate( root ).
-      CATCH cx_sy_conversion_error.
-        " parse error — return initial (null ref)
-    ENDTRY.
+    DATA(root) = lcl_parser=>parse( lcl_scanner=>scan( yaml ) ).
+    rr_data = lcl_gen_mapper=>generate( root ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -20,6 +20,8 @@ CLASS z_ui2_yaml DEFINITION
         extended    TYPE c LENGTH 1 VALUE 'Y',
       END OF pretty_mode.
 
+    TYPES ref_tab TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY.
+
     CONSTANTS version TYPE i VALUE 1 ##NO_TEXT.
 
     METHODS constructor
@@ -36,6 +38,11 @@ CLASS z_ui2_yaml DEFINITION
       IMPORTING yaml  TYPE string  OPTIONAL
                 yamlx TYPE xstring OPTIONAL
       CHANGING  data  TYPE data
+      RAISING   cx_sy_move_cast_error.
+
+    METHODS deserialize_all_int
+      IMPORTING yaml TYPE string
+      CHANGING  results TYPE STANDARD TABLE
       RAISING   cx_sy_move_cast_error.
 
     CLASS-METHODS serialize
@@ -59,9 +66,20 @@ CLASS z_ui2_yaml DEFINITION
                 name_mappings TYPE name_mappings    OPTIONAL
       CHANGING  data          TYPE data.
 
+    CLASS-METHODS deserialize_all
+      IMPORTING yaml          TYPE string
+                pretty_name   TYPE pretty_name_mode DEFAULT pretty_mode-none
+                name_mappings TYPE name_mappings    OPTIONAL
+      CHANGING  results       TYPE STANDARD TABLE.
+
     CLASS-METHODS generate
       IMPORTING yaml           TYPE string
       RETURNING VALUE(rr_data) TYPE REF TO data
+      RAISING   cx_sy_conversion_error.
+
+    CLASS-METHODS generate_all
+      IMPORTING yaml           TYPE string
+      RETURNING VALUE(rt_data) TYPE ref_tab
       RAISING   cx_sy_conversion_error.
 
   PROTECTED SECTION.
@@ -144,6 +162,57 @@ CLASS z_ui2_yaml IMPLEMENTATION.
   METHOD generate.
     DATA(root) = lcl_parser=>parse( lcl_scanner=>scan( yaml ) ).
     rr_data = lcl_gen_mapper=>generate( root ).
+  ENDMETHOD.
+
+  METHOD generate_all.
+    DATA(all_lines) = lcl_scanner=>scan( yaml ).
+    DATA(blocks) = lcl_parser=>split_documents( all_lines ).
+    IF blocks IS INITIAL.
+      " no boundaries found — treat whole input as single doc
+      DATA(single_root) = lcl_parser=>parse( all_lines ).
+      APPEND lcl_gen_mapper=>generate( single_root ) TO rt_data.
+      RETURN.
+    ENDIF.
+    LOOP AT blocks INTO DATA(block).
+      DATA(root) = lcl_parser=>parse( block ).
+      APPEND lcl_gen_mapper=>generate( root ) TO rt_data.
+    ENDLOOP.
+  ENDMETHOD.
+
+  METHOD deserialize_all_int.
+    DATA(all_lines) = lcl_scanner=>scan( yaml ).
+    DATA(blocks) = lcl_parser=>split_documents( all_lines ).
+    IF blocks IS INITIAL.
+      " no boundaries — single doc
+      DATA single_block TYPE ty_lines.
+      single_block = all_lines.
+      INSERT single_block INTO TABLE blocks.
+    ENDIF.
+    DATA(tabd) = CAST cl_abap_tabledescr( cl_abap_typedescr=>describe_by_data( results ) ).
+    DATA(line_td) = tabd->get_table_line_type( ).
+    LOOP AT blocks INTO DATA(block).
+      DATA lv_line_ref TYPE REF TO data.
+      CREATE DATA lv_line_ref TYPE HANDLE line_td.
+      ASSIGN lv_line_ref->* TO FIELD-SYMBOL(<line>).
+      DATA(root) = lcl_parser=>parse( block ).
+      lcl_typed_mapper=>map( EXPORTING node          = root
+                                       pretty_name   = mv_pretty_name
+                                       name_mappings = mt_name_mappings
+                                       strict        = mv_strict
+                             CHANGING  data          = <line> ).
+      INSERT <line> INTO TABLE results.
+    ENDLOOP.
+  ENDMETHOD.
+
+  METHOD deserialize_all.
+    DATA(o) = NEW z_ui2_yaml( pretty_name   = pretty_name
+                              name_mappings = name_mappings ).
+    TRY.
+        o->deserialize_all_int( EXPORTING yaml    = yaml
+                                CHANGING  results = results ).
+      CATCH cx_sy_move_cast_error.
+        " lenient — mirrors static deserialize
+    ENDTRY.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -38,12 +38,14 @@ CLASS z_ui2_yaml DEFINITION
       IMPORTING yaml  TYPE string  OPTIONAL
                 yamlx TYPE xstring OPTIONAL
       CHANGING  data  TYPE data
-      RAISING   cx_sy_move_cast_error.
+      RAISING   cx_sy_move_cast_error
+                cx_sy_conversion_error.
 
     METHODS deserialize_all_int
       IMPORTING yaml TYPE string
       CHANGING  results TYPE STANDARD TABLE
-      RAISING   cx_sy_move_cast_error.
+      RAISING   cx_sy_move_cast_error
+                cx_sy_conversion_error.
 
     CLASS-METHODS serialize
       IMPORTING data           TYPE data
@@ -154,8 +156,8 @@ CLASS z_ui2_yaml IMPLEMENTATION.
         o->deserialize_int( EXPORTING yaml  = yaml
                                       yamlx = yamlx
                             CHANGING  data  = data ).
-      CATCH cx_sy_move_cast_error.
-        " static API is lenient — strict_mode defaults false, so unreachable by design
+      CATCH cx_sy_move_cast_error cx_sy_conversion_error.
+        " static API is lenient — absorb structural parse errors (tab-in-indent, bad dedent, etc.)
     ENDTRY.
   ENDMETHOD.
 
@@ -210,7 +212,7 @@ CLASS z_ui2_yaml IMPLEMENTATION.
     TRY.
         o->deserialize_all_int( EXPORTING yaml    = yaml
                                 CHANGING  results = results ).
-      CATCH cx_sy_move_cast_error.
+      CATCH cx_sy_move_cast_error cx_sy_conversion_error.
         " lenient — mirrors static deserialize
     ENDTRY.
   ENDMETHOD.

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -1,0 +1,32 @@
+CLASS z_ui2_yaml DEFINITION
+  PUBLIC
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+    TYPES yaml TYPE string.
+    TYPES pretty_name_mode TYPE c LENGTH 1.
+    TYPES: BEGIN OF name_mapping,
+             abap TYPE abap_compname,
+             yaml TYPE string,
+           END OF name_mapping.
+    TYPES name_mappings TYPE HASHED TABLE OF name_mapping WITH UNIQUE KEY abap.
+
+    CONSTANTS:
+      BEGIN OF pretty_mode,
+        none        TYPE c LENGTH 1 VALUE ``,
+        low_case    TYPE c LENGTH 1 VALUE 'L',
+        camel_case  TYPE c LENGTH 1 VALUE 'X',
+        pascal_case TYPE c LENGTH 1 VALUE 'P',
+        extended    TYPE c LENGTH 1 VALUE 'Y',
+      END OF pretty_mode.
+
+    CONSTANTS version TYPE i VALUE 1 ##NO_TEXT.
+
+    " methods added in Tasks 8-11
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+ENDCLASS.
+
+CLASS z_ui2_yaml IMPLEMENTATION.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -38,6 +38,20 @@ CLASS z_ui2_yaml DEFINITION
       CHANGING  data  TYPE data
       RAISING   cx_sy_move_cast_error.
 
+    CLASS-METHODS serialize
+      IMPORTING data           TYPE data
+                name           TYPE string        OPTIONAL
+                compress       TYPE abap_bool     DEFAULT abap_false
+                pretty_name    TYPE pretty_name_mode DEFAULT pretty_mode-none
+                name_mappings  TYPE name_mappings OPTIONAL
+                header_comment TYPE string        OPTIONAL
+      RETURNING VALUE(r_yaml)  TYPE yaml.
+
+    METHODS serialize_int
+      IMPORTING data           TYPE data
+                name           TYPE string OPTIONAL
+      RETURNING VALUE(r_yaml)  TYPE yaml.
+
     CLASS-METHODS deserialize
       IMPORTING yaml          TYPE string           OPTIONAL
                 yamlx         TYPE xstring          OPTIONAL
@@ -73,6 +87,31 @@ CLASS z_ui2_yaml IMPLEMENTATION.
     mv_emit_doc_markers = emit_doc_markers.
     mv_quote_style      = COND #( WHEN quote_style IS SUPPLIED THEN quote_style ELSE 'P' ).
     mv_flow_threshold   = COND #( WHEN flow_threshold IS SUPPLIED THEN flow_threshold ELSE 0 ).
+  ENDMETHOD.
+
+  METHOD serialize_int.
+    r_yaml = lcl_emitter=>emit( data           = data
+                                name           = name
+                                compress       = abap_false
+                                pretty_name    = mv_pretty_name
+                                name_mappings  = mt_name_mappings
+                                indent_step    = mv_indent
+                                quote_style    = mv_quote_style
+                                emit_doc_markers = mv_emit_doc_markers ).
+  ENDMETHOD.
+
+  METHOD serialize.
+    DATA(o) = NEW z_ui2_yaml( pretty_name   = pretty_name
+                              name_mappings = name_mappings ).
+    r_yaml = lcl_emitter=>emit( data           = data
+                                name           = name
+                                compress       = compress
+                                pretty_name    = pretty_name
+                                name_mappings  = name_mappings
+                                indent_step    = 2
+                                quote_style    = 'P'
+                                emit_doc_markers = abap_false
+                                header_comment = header_comment ).
   ENDMETHOD.
 
   METHOD deserialize_int.

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -101,8 +101,6 @@ CLASS z_ui2_yaml IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD serialize.
-    DATA(o) = NEW z_ui2_yaml( pretty_name   = pretty_name
-                              name_mappings = name_mappings ).
     r_yaml = lcl_emitter=>emit( data           = data
                                 name           = name
                                 compress       = compress

--- a/src/z_ui2_yaml.clas.abap
+++ b/src/z_ui2_yaml.clas.abap
@@ -168,14 +168,7 @@ CLASS z_ui2_yaml IMPLEMENTATION.
 
   METHOD generate_all.
     DATA(all_lines) = lcl_scanner=>scan( yaml ).
-    DATA(blocks) = lcl_parser=>split_documents( all_lines ).
-    IF blocks IS INITIAL.
-      " no boundaries found — treat whole input as single doc
-      DATA(single_root) = lcl_parser=>parse( all_lines ).
-      APPEND lcl_gen_mapper=>generate( single_root ) TO rt_data.
-      RETURN.
-    ENDIF.
-    LOOP AT blocks INTO DATA(block).
+    LOOP AT lcl_parser=>split_documents( all_lines ) INTO DATA(block).
       DATA(root) = lcl_parser=>parse( block ).
       APPEND lcl_gen_mapper=>generate( root ) TO rt_data.
     ENDLOOP.
@@ -183,16 +176,9 @@ CLASS z_ui2_yaml IMPLEMENTATION.
 
   METHOD deserialize_all_int.
     DATA(all_lines) = lcl_scanner=>scan( yaml ).
-    DATA(blocks) = lcl_parser=>split_documents( all_lines ).
-    IF blocks IS INITIAL.
-      " no boundaries — single doc
-      DATA single_block TYPE ty_lines.
-      single_block = all_lines.
-      INSERT single_block INTO TABLE blocks.
-    ENDIF.
     DATA(tabd) = CAST cl_abap_tabledescr( cl_abap_typedescr=>describe_by_data( results ) ).
     DATA(line_td) = tabd->get_table_line_type( ).
-    LOOP AT blocks INTO DATA(block).
+    LOOP AT lcl_parser=>split_documents( all_lines ) INTO DATA(block).
       DATA lv_line_ref TYPE REF TO data.
       CREATE DATA lv_line_ref TYPE HANDLE line_td.
       ASSIGN lv_line_ref->* TO FIELD-SYMBOL(<line>).

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -27,11 +27,13 @@ TYPES:
     indent        TYPE i,
     content       TYPE string,
     doc_marker    TYPE abap_bool,
+    doc_start     TYPE abap_bool,
     blk_scalar_hd TYPE abap_bool,
     blk_value     TYPE string,
     blk_anchor    TYPE string,
   END OF ty_line.
 TYPES ty_lines TYPE STANDARD TABLE OF ty_line WITH DEFAULT KEY.
+TYPES tt_line_blocks TYPE STANDARD TABLE OF ty_lines WITH DEFAULT KEY.
 
 "=== Anchor table entry ================================================
 
@@ -102,6 +104,9 @@ CLASS lcl_parser DEFINITION.
       IMPORTING lines       TYPE ty_lines
       RETURNING VALUE(root) TYPE ty_node_ref
       RAISING   cx_sy_conversion_error.
+    CLASS-METHODS split_documents
+      IMPORTING lines          TYPE ty_lines
+      RETURNING VALUE(rt_blocks) TYPE tt_line_blocks.
     CLASS-METHODS resolve_scalar
       IMPORTING raw     TYPE string
       EXPORTING value   TYPE string

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -216,6 +216,15 @@ CLASS lcl_gen_mapper DEFINITION.
       RAISING   cx_sy_conversion_error.
   PRIVATE SECTION.
     CONSTANTS c_max_comp_name_len TYPE i VALUE 30.
+    " ponytail: session-scoped, single-threaded. Caches struct type descriptors by
+    " component-name fingerprint so 100k identical rows reuse the same RTTI struct
+    " instead of calling cl_abap_structdescr=>create() 100k times.
+    TYPES: BEGIN OF ty_struct_td_entry,
+             fingerprint TYPE string,
+             struct_td   TYPE REF TO cl_abap_structdescr,
+           END OF ty_struct_td_entry.
+    CLASS-DATA mt_struct_td_cache TYPE HASHED TABLE OF ty_struct_td_entry
+                                   WITH UNIQUE KEY fingerprint.
     "! Detect scalar type by char checks and return a typed data ref.
     "! Integer:   1-9 digit string (optional leading '-') → TYPE i.
     "!            ponytail: 10+ digit integers fall back to TYPE string.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -136,7 +136,9 @@ CLASS lcl_parser DEFINITION.
       RETURNING VALUE(node)  TYPE ty_node_ref
       RAISING   cx_sy_conversion_error.
   PRIVATE SECTION.
-    " NOT thread-safe: class-data is cleared at parse() entry; concurrent calls will corrupt anchor state
+    " mt_anchors: per-parse state, CLEARed at parse() entry. ABAP class-data is session-scoped
+    " and single-threaded — no cross-call concern. Reset-at-entry means parse() is not reentrant
+    " (never call it recursively), but the current call tree never does.
     CLASS-DATA mt_anchors TYPE HASHED TABLE OF ty_anchor_entry WITH UNIQUE KEY name.
     CLASS-METHODS strip_anchor
       CHANGING  raw          TYPE string

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -202,4 +202,43 @@ ENDCLASS.
 
 CLASS lcl_emitter DEFINITION.
   PUBLIC SECTION.
+    CLASS-METHODS emit
+      IMPORTING data             TYPE data
+                name             TYPE string        OPTIONAL
+                compress         TYPE abap_bool
+                pretty_name      TYPE z_ui2_yaml=>pretty_name_mode
+                name_mappings    TYPE z_ui2_yaml=>name_mappings
+                indent_step      TYPE i
+                quote_style      TYPE c
+                emit_doc_markers TYPE abap_bool
+                header_comment   TYPE string        OPTIONAL
+      RETURNING VALUE(r_yaml)    TYPE string.
+  PRIVATE SECTION.
+    CLASS-METHODS emit_node
+      IMPORTING data          TYPE data
+                compress      TYPE abap_bool
+                pretty_name   TYPE z_ui2_yaml=>pretty_name_mode
+                name_mappings TYPE z_ui2_yaml=>name_mappings
+                indent_step   TYPE i
+                quote_style   TYPE c
+      RETURNING VALUE(result) TYPE string.
+    CLASS-METHODS format_key
+      IMPORTING comp_name     TYPE abap_compname
+                pretty_name   TYPE z_ui2_yaml=>pretty_name_mode
+                name_mappings TYPE z_ui2_yaml=>name_mappings
+      RETURNING VALUE(result) TYPE string.
+    CLASS-METHODS quote_scalar
+      IMPORTING value         TYPE string
+                quote_style   TYPE c
+      RETURNING VALUE(result) TYPE string.
+    CLASS-METHODS escape_dq
+      IMPORTING value         TYPE string
+      RETURNING VALUE(result) TYPE string.
+    CLASS-METHODS looks_like_number
+      IMPORTING value         TYPE string
+      RETURNING VALUE(result) TYPE abap_bool.
+    CLASS-METHODS indent_block
+      IMPORTING text          TYPE string
+                n             TYPE i
+      RETURNING VALUE(result) TYPE string.
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -32,6 +32,14 @@ TYPES:
   END OF ty_line.
 TYPES ty_lines TYPE STANDARD TABLE OF ty_line WITH DEFAULT KEY.
 
+"=== Anchor table entry ================================================
+
+TYPES:
+  BEGIN OF ty_anchor_entry,
+    name TYPE string,
+    node TYPE ty_node_ref,
+  END OF ty_anchor_entry.
+
 "=== Node kind constants ===============================================
 
 CLASS c_node DEFINITION FINAL.
@@ -103,6 +111,16 @@ CLASS lcl_parser DEFINITION.
       RETURNING VALUE(node)  TYPE ty_node_ref
       RAISING   cx_sy_conversion_error.
   PRIVATE SECTION.
+    " ponytail: class-data anchor table — single-threaded/one-run state, cleared at parse() entry
+    CLASS-DATA mt_anchors TYPE HASHED TABLE OF ty_anchor_entry WITH UNIQUE KEY name.
+    CLASS-METHODS strip_anchor
+      CHANGING  raw          TYPE string
+      RETURNING VALUE(aname) TYPE string.
+    CLASS-METHODS resolve_alias
+      IMPORTING raw          TYPE string
+                lineno        TYPE i DEFAULT 0
+      RETURNING VALUE(node)  TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
     CLASS-METHODS parse_block
       IMPORTING lines        TYPE ty_lines
       CHANGING  idx          TYPE i

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -1,0 +1,72 @@
+*"* use this source file for your LOCAL class DEFINITION
+*"* which is only visible within this one class include
+
+"=== Shared node-tree types =============================================
+
+TYPES:
+  BEGIN OF ty_node,
+    kind     TYPE c LENGTH 1,  "S"=scalar "M"=mapping "Q"=sequence
+    value    TYPE string,
+  END OF ty_node.
+
+CLASS lcl_node_ref DEFINITION DEFERRED.
+TYPES ty_node_ref TYPE REF TO lcl_node_ref.
+TYPES:
+  BEGIN OF ty_child,
+    key  TYPE string,
+    node TYPE ty_node_ref,
+  END OF ty_child.
+TYPES ty_children TYPE STANDARD TABLE OF ty_child WITH DEFAULT KEY.
+
+"=== Shared scanner line types =========================================
+
+TYPES:
+  BEGIN OF ty_line,
+    indent        TYPE i,
+    content       TYPE string,
+    doc_marker    TYPE abap_bool,
+    blk_scalar_hd TYPE abap_bool,
+  END OF ty_line.
+TYPES ty_lines TYPE STANDARD TABLE OF ty_line WITH DEFAULT KEY.
+
+"=== Node kind constants ===============================================
+
+CLASS c_node DEFINITION FINAL.
+  PUBLIC SECTION.
+    CONSTANTS:
+      scalar   TYPE c LENGTH 1 VALUE 'S',
+      mapping  TYPE c LENGTH 1 VALUE 'M',
+      sequence TYPE c LENGTH 1 VALUE 'Q'.
+ENDCLASS.
+
+"=== Node ref carrier ==================================================
+
+CLASS lcl_node_ref DEFINITION FINAL.
+  PUBLIC SECTION.
+    DATA node      TYPE ty_node.
+    DATA children  TYPE ty_children.
+ENDCLASS.
+
+"=== Empty local class definitions (implementations in locals_imp) ====
+
+CLASS lcl_scanner DEFINITION.
+  PUBLIC SECTION.
+    " filled in Task 2
+ENDCLASS.
+
+CLASS lcl_parser DEFINITION.
+  PUBLIC SECTION.
+    " filled in Task 4
+ENDCLASS.
+
+CLASS lcl_typed_mapper DEFINITION.
+  PUBLIC SECTION.
+ENDCLASS.
+
+CLASS lcl_gen_mapper DEFINITION.
+  PUBLIC SECTION.
+ENDCLASS.
+
+CLASS lcl_emitter DEFINITION.
+  PUBLIC SECTION.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -7,6 +7,7 @@ TYPES:
   BEGIN OF ty_node,
     kind     TYPE c LENGTH 1,  "S"=scalar "M"=mapping "Q"=sequence
     value    TYPE string,
+    is_null  TYPE abap_bool,
   END OF ty_node.
 
 CLASS lcl_node_ref DEFINITION DEFERRED.
@@ -22,6 +23,7 @@ TYPES ty_children TYPE STANDARD TABLE OF ty_child WITH DEFAULT KEY.
 
 TYPES:
   BEGIN OF ty_line,
+    lineno        TYPE i,
     indent        TYPE i,
     content       TYPE string,
     doc_marker    TYPE abap_bool,

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -28,6 +28,7 @@ TYPES:
     content       TYPE string,
     doc_marker    TYPE abap_bool,
     blk_scalar_hd TYPE abap_bool,
+    blk_value     TYPE string,
   END OF ty_line.
 TYPES ty_lines TYPE STANDARD TABLE OF ty_line WITH DEFAULT KEY.
 

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -172,6 +172,11 @@ CLASS lcl_typed_mapper DEFINITION.
                 strict        TYPE abap_bool
       CHANGING  data          TYPE data
       RAISING   cx_sy_move_cast_error.
+  PRIVATE SECTION.
+    CLASS-METHODS pretty_inverse
+      IMPORTING yaml_key        TYPE string
+                pretty_name     TYPE z_ui2_yaml=>pretty_name_mode
+      RETURNING VALUE(abap_name) TYPE string.
 ENDCLASS.
 
 CLASS lcl_gen_mapper DEFINITION.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -49,6 +49,23 @@ CLASS lcl_node_ref DEFINITION FINAL.
     DATA children  TYPE ty_children.
 ENDCLASS.
 
+"=== Node-tree factory =================================================
+
+CLASS lcl_tree DEFINITION.
+  PUBLIC SECTION.
+    CLASS-METHODS new_scalar
+      IMPORTING value   TYPE string
+                is_null TYPE abap_bool DEFAULT abap_false
+      RETURNING VALUE(node) TYPE ty_node_ref.
+    CLASS-METHODS new_collection
+      IMPORTING kind        TYPE c
+      RETURNING VALUE(node) TYPE ty_node_ref.
+    CLASS-METHODS add_child
+      IMPORTING node  TYPE ty_node_ref
+                key   TYPE string OPTIONAL
+                child TYPE ty_node_ref.
+ENDCLASS.
+
 "=== Scanner ===========================================================
 
 CLASS lcl_scanner DEFINITION.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -65,6 +65,14 @@ ENDCLASS.
 
 CLASS lcl_tree DEFINITION.
   PUBLIC SECTION.
+    CONSTANTS c_yaml_name_chars TYPE string
+      VALUE 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-'.
+    CLASS-METHODS is_bool_type
+      IMPORTING eld           TYPE REF TO cl_abap_elemdescr
+      RETURNING VALUE(result) TYPE abap_bool.
+    CLASS-METHODS is_date_like
+      IMPORTING value         TYPE string
+      RETURNING VALUE(result) TYPE abap_bool.
     CLASS-METHODS new_scalar
       IMPORTING value   TYPE string
                 is_null TYPE abap_bool DEFAULT abap_false
@@ -245,9 +253,6 @@ CLASS lcl_emitter DEFINITION.
     CLASS-METHODS escape_dq
       IMPORTING value         TYPE string
       RETURNING VALUE(result) TYPE string.
-    CLASS-METHODS looks_like_number
-      IMPORTING value         TYPE string
-      RETURNING VALUE(result) TYPE abap_bool.
     CLASS-METHODS indent_block
       IMPORTING text          TYPE string
                 n             TYPE i

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -165,6 +165,13 @@ ENDCLASS.
 
 CLASS lcl_typed_mapper DEFINITION.
   PUBLIC SECTION.
+    CLASS-METHODS map
+      IMPORTING node          TYPE ty_node_ref
+                pretty_name   TYPE z_ui2_yaml=>pretty_name_mode
+                name_mappings TYPE z_ui2_yaml=>name_mappings
+                strict        TYPE abap_bool
+      CHANGING  data          TYPE data
+      RAISING   cx_sy_move_cast_error.
 ENDCLASS.
 
 CLASS lcl_gen_mapper DEFINITION.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -89,6 +89,15 @@ CLASS lcl_parser DEFINITION.
       IMPORTING lines       TYPE ty_lines
       RETURNING VALUE(root) TYPE ty_node_ref
       RAISING   cx_sy_conversion_error.
+    CLASS-METHODS resolve_scalar
+      IMPORTING raw     TYPE string
+      EXPORTING value   TYPE string
+                is_null TYPE abap_bool
+      RAISING   cx_sy_conversion_error.
+    CLASS-METHODS parse_flow
+      IMPORTING raw          TYPE string
+      RETURNING VALUE(node)  TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
   PRIVATE SECTION.
     CLASS-METHODS parse_block
       IMPORTING lines        TYPE ty_lines

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -120,6 +120,7 @@ CLASS lcl_parser DEFINITION.
       EXPORTING key          TYPE string
                 inline_value TYPE string
                 has_inline   TYPE abap_bool
+                is_mapping   TYPE abap_bool
       RAISING   cx_sy_conversion_error.
     CLASS-METHODS value_or_block
       IMPORTING lines        TYPE ty_lines

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -104,6 +104,17 @@ CLASS lcl_scanner DEFINITION.
     CLASS-METHODS trim_right
       IMPORTING body          TYPE string
       RETURNING VALUE(result) TYPE string.
+    CLASS-METHODS collect_block_body
+      IMPORTING raw       TYPE string_table
+                start_n   TYPE i
+                indent    TYPE i
+                total     TYPE i
+      EXPORTING rt_body   TYPE string_table
+                rv_next_n TYPE i.
+    CLASS-METHODS assemble_block_value
+      IMPORTING blk_body       TYPE string_table
+                blk_scalar_ind TYPE string
+      RETURNING VALUE(rv_val)  TYPE string.
 ENDCLASS.
 
 CLASS lcl_parser DEFINITION.
@@ -125,7 +136,7 @@ CLASS lcl_parser DEFINITION.
       RETURNING VALUE(node)  TYPE ty_node_ref
       RAISING   cx_sy_conversion_error.
   PRIVATE SECTION.
-    " ponytail: class-data anchor table — single-threaded/one-run state, cleared at parse() entry
+    " NOT thread-safe: class-data is cleared at parse() entry; concurrent calls will corrupt anchor state
     CLASS-DATA mt_anchors TYPE HASHED TABLE OF ty_anchor_entry WITH UNIQUE KEY name.
     CLASS-METHODS strip_anchor
       CHANGING  raw          TYPE string
@@ -202,6 +213,7 @@ CLASS lcl_gen_mapper DEFINITION.
       RETURNING VALUE(rr_data) TYPE REF TO data
       RAISING   cx_sy_conversion_error.
   PRIVATE SECTION.
+    CONSTANTS c_max_comp_name_len TYPE i VALUE 30.
     "! Detect scalar type by char checks and return a typed data ref.
     "! Integer:   1-9 digit string (optional leading '-') → TYPE i.
     "!            ponytail: 10+ digit integers fall back to TYPE string.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -176,6 +176,28 @@ ENDCLASS.
 
 CLASS lcl_gen_mapper DEFINITION.
   PUBLIC SECTION.
+    "! Build a typed REF TO data tree from a parsed YAML node (always-optimized: no REF TO data
+    "! wrappers around leaf values).  Scalars are typed by character-check detection (no regex).
+    CLASS-METHODS generate
+      IMPORTING node          TYPE ty_node_ref
+      RETURNING VALUE(rr_data) TYPE REF TO data
+      RAISING   cx_sy_conversion_error.
+  PRIVATE SECTION.
+    "! Detect scalar type by char checks and return a typed data ref.
+    "! Integer:   1-9 digit string (optional leading '-') → TYPE i.
+    "!            ponytail: 10+ digit integers fall back to TYPE string.
+    "! Decimal:   digits + single '.' → TYPE decfloat34.
+    "! Boolean:   exact tokens 'true'/'false' → TYPE abap_bool ('X'/'').
+    "! Date:      YYYY-MM-DD (10 chars, '-' at pos 4+7, digits elsewhere) → TYPE d.
+    "! Else:      TYPE string.
+    CLASS-METHODS detect_scalar_type
+      IMPORTING value          TYPE string
+      RETURNING VALUE(rr_data) TYPE REF TO data.
+    "! Uppercase raw key, replace invalid ABAP component chars with '_',
+    "! prefix with 'F' if first char is a digit.  Max 30 chars.
+    CLASS-METHODS sanitize_name
+      IMPORTING raw            TYPE string
+      RETURNING VALUE(result)  TYPE abap_compname.
 ENDCLASS.
 
 CLASS lcl_emitter DEFINITION.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -29,6 +29,7 @@ TYPES:
     doc_marker    TYPE abap_bool,
     blk_scalar_hd TYPE abap_bool,
     blk_value     TYPE string,
+    blk_anchor    TYPE string,
   END OF ty_line.
 TYPES ty_lines TYPE STANDARD TABLE OF ty_line WITH DEFAULT KEY.
 

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -85,7 +85,50 @@ ENDCLASS.
 
 CLASS lcl_parser DEFINITION.
   PUBLIC SECTION.
-    " filled in Task 4
+    CLASS-METHODS parse
+      IMPORTING lines       TYPE ty_lines
+      RETURNING VALUE(root) TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
+  PRIVATE SECTION.
+    CLASS-METHODS parse_block
+      IMPORTING lines        TYPE ty_lines
+      CHANGING  idx          TYPE i
+      RETURNING VALUE(node)  TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
+    CLASS-METHODS parse_mapping
+      IMPORTING lines        TYPE ty_lines
+                own_indent   TYPE i
+      CHANGING  idx          TYPE i
+      RETURNING VALUE(node)  TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
+    CLASS-METHODS parse_sequence
+      IMPORTING lines        TYPE ty_lines
+                own_indent   TYPE i
+      CHANGING  idx          TYPE i
+      RETURNING VALUE(node)  TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
+    CLASS-METHODS parse_seq_item
+      IMPORTING lines        TYPE ty_lines
+                own_indent   TYPE i
+                rest         TYPE string
+      CHANGING  idx          TYPE i
+      RETURNING VALUE(node)  TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
+    CLASS-METHODS split_key_value
+      IMPORTING content      TYPE string
+                lineno       TYPE i
+      EXPORTING key          TYPE string
+                inline_value TYPE string
+                has_inline   TYPE abap_bool
+      RAISING   cx_sy_conversion_error.
+    CLASS-METHODS value_or_block
+      IMPORTING lines        TYPE ty_lines
+                own_indent   TYPE i
+                has_inline   TYPE abap_bool
+                inline_value TYPE string
+      CHANGING  idx          TYPE i
+      RETURNING VALUE(node)  TYPE ty_node_ref
+      RAISING   cx_sy_conversion_error.
 ENDCLASS.
 
 CLASS lcl_typed_mapper DEFINITION.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -49,11 +49,21 @@ CLASS lcl_node_ref DEFINITION FINAL.
     DATA children  TYPE ty_children.
 ENDCLASS.
 
-"=== Empty local class definitions (implementations in locals_imp) ====
+"=== Scanner ===========================================================
 
 CLASS lcl_scanner DEFINITION.
   PUBLIC SECTION.
-    " filled in Task 2
+    CLASS-METHODS scan
+      IMPORTING text         TYPE string
+      RETURNING VALUE(lines) TYPE ty_lines
+      RAISING   cx_sy_conversion_error.
+  PRIVATE SECTION.
+    CLASS-METHODS strip_comment
+      IMPORTING body          TYPE string
+      RETURNING VALUE(result) TYPE string.
+    CLASS-METHODS trim_right
+      IMPORTING body          TYPE string
+      RETURNING VALUE(result) TYPE string.
 ENDCLASS.
 
 CLASS lcl_parser DEFINITION.

--- a/src/z_ui2_yaml.clas.locals_def.abap
+++ b/src/z_ui2_yaml.clas.locals_def.abap
@@ -74,6 +74,9 @@ CLASS lcl_scanner DEFINITION.
       IMPORTING text         TYPE string
       RETURNING VALUE(lines) TYPE ty_lines
       RAISING   cx_sy_conversion_error.
+    CLASS-METHODS trim
+      IMPORTING val           TYPE string
+      RETURNING VALUE(result) TYPE string.
   PRIVATE SECTION.
     CLASS-METHODS strip_comment
       IMPORTING body          TYPE string

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -111,6 +111,9 @@ CLASS lcl_scanner IMPLEMENTATION.
       body   = strip_comment( body ).
       body   = trim_right( body ).
       IF body IS INITIAL OR body = `---`.
+        IF body = `---`.
+          APPEND VALUE ty_line( lineno = n indent = 0 doc_start = abap_true ) TO lines.
+        ENDIF.
         n = n + 1.
         CONTINUE.
       ENDIF.
@@ -364,12 +367,53 @@ CLASS lcl_parser IMPLEMENTATION.
 
   METHOD parse.
     CLEAR mt_anchors.
+    " Build first-doc view: a leading doc_start (---) with no prior content is skipped
+    " (preamble marker); a doc_start encountered AFTER content ends the first doc.
+    " doc_marker (...) also ends the first doc.
+    " This preserves backward-compat: single-doc parse sees exactly the first document.
+    DATA first_doc TYPE ty_lines.
+    LOOP AT lines INTO DATA(scan_ln).
+      IF scan_ln-doc_start = abap_true.
+        IF first_doc IS NOT INITIAL.
+          EXIT.  " content already collected — this --- starts doc 2
+        ENDIF.
+        CONTINUE.  " leading --- with no prior content: preamble, skip
+      ENDIF.
+      IF scan_ln-doc_marker = abap_true.
+        EXIT.  " ... ends first doc
+      ENDIF.
+      APPEND scan_ln TO first_doc.
+    ENDLOOP.
     DATA(idx) = 1.
-    IF lines IS INITIAL.
+    IF first_doc IS INITIAL.
       root = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
       RETURN.
     ENDIF.
-    root = parse_block( EXPORTING lines = lines CHANGING idx = idx ).
+    root = parse_block( EXPORTING lines = first_doc CHANGING idx = idx ).
+  ENDMETHOD.
+
+  METHOD split_documents.
+    " Partition lines at doc_start (---) and doc_marker (...) boundaries.
+    " A leading --- does NOT produce an empty first block.
+    DATA cur_block TYPE ty_lines.
+    LOOP AT lines INTO DATA(ln).
+      IF ln-doc_start = abap_true.
+        IF cur_block IS NOT INITIAL.
+          APPEND cur_block TO rt_blocks.
+          CLEAR cur_block.
+        ENDIF.
+      ELSEIF ln-doc_marker = abap_true.
+        IF cur_block IS NOT INITIAL.
+          APPEND cur_block TO rt_blocks.
+          CLEAR cur_block.
+        ENDIF.
+      ELSE.
+        APPEND ln TO cur_block.
+      ENDIF.
+    ENDLOOP.
+    IF cur_block IS NOT INITIAL.
+      APPEND cur_block TO rt_blocks.
+    ENDIF.
   ENDMETHOD.
 
   METHOD parse_block.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -100,7 +100,10 @@ CLASS lcl_parser IMPLEMENTATION.
       IF lv_is_mapping = abap_true.
         node = parse_mapping( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
       ELSE.
-        node = lcl_tree=>new_scalar( value = first ).
+        DATA lv_bv TYPE string.
+        DATA lv_bn TYPE abap_bool.
+        resolve_scalar( EXPORTING raw = first IMPORTING value = lv_bv is_null = lv_bn ).
+        node = lcl_tree=>new_scalar( value = lv_bv is_null = lv_bn ).
         idx = idx + 1.
       ENDIF.
     ENDIF.
@@ -172,32 +175,50 @@ CLASS lcl_parser IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD split_key_value.
-    DATA len TYPE i.
-    DATA i   TYPE i.
+    " Quote-aware colon scan: skip ':' inside single/double quotes
+    DATA len   TYPE i.
+    DATA i     TYPE i.
+    DATA in_sq TYPE abap_bool VALUE abap_false.
+    DATA in_dq TYPE abap_bool VALUE abap_false.
     len = strlen( content ).
     WHILE i < len.
       DATA(ch) = substring( val = content off = i len = 1 ).
-      IF ch = `:`.
-        DATA(next_pos) = i + 1.
-        IF next_pos >= len.
-          " key: (nothing after colon)
-          key          = substring( val = content len = i ).
-          inline_value = ``.
-          has_inline   = abap_false.
-          is_mapping   = abap_true.
-          RETURN.
+      IF in_sq = abap_true.
+        " escaped '' inside single-quoted string
+        IF ch = `'` AND i + 1 < len AND substring( val = content off = i + 1 len = 1 ) = `'`.
+          i = i + 2.
+          CONTINUE.
         ENDIF.
-        DATA(next_ch) = substring( val = content off = next_pos len = 1 ).
-        IF next_ch = ` `.
-          key = substring( val = content len = i ).
-          DATA(val_off) = i + 2.
-          IF val_off < len.
-            inline_value = substring( val = content off = val_off ).
-          ENDIF.
-          has_inline = abap_true.
-          is_mapping = abap_true.
-          RETURN.
-        ENDIF.
+        IF ch = `'`. in_sq = abap_false. ENDIF.
+      ELSEIF in_dq = abap_true.
+        IF ch = `\` AND i + 1 < len. i = i + 2. CONTINUE. ENDIF.
+        IF ch = `"`. in_dq = abap_false. ENDIF.
+      ELSE.
+        CASE ch.
+          WHEN `'`. in_sq = abap_true.
+          WHEN `"`. in_dq = abap_true.
+          WHEN `:`.
+            DATA(next_pos) = i + 1.
+            IF next_pos >= len.
+              " key: (nothing after colon)
+              key          = substring( val = content len = i ).
+              inline_value = ``.
+              has_inline   = abap_false.
+              is_mapping   = abap_true.
+              RETURN.
+            ENDIF.
+            DATA(next_ch) = substring( val = content off = next_pos len = 1 ).
+            IF next_ch = ` `.
+              key = substring( val = content len = i ).
+              DATA(val_off) = i + 2.
+              IF val_off < len.
+                inline_value = substring( val = content off = val_off ).
+              ENDIF.
+              has_inline = abap_true.
+              is_mapping = abap_true.
+              RETURN.
+            ENDIF.
+        ENDCASE.
       ENDIF.
       i = i + 1.
     ENDWHILE.
@@ -209,12 +230,219 @@ CLASS lcl_parser IMPLEMENTATION.
 
   METHOD value_or_block.
     IF has_inline = abap_true.
-      node = lcl_tree=>new_scalar( value = inline_value ).
+      DATA(trimmed) = condense( inline_value ).
+      IF strlen( trimmed ) > 0 AND
+         ( substring( val = trimmed off = 0 len = 1 ) = `{` OR
+           substring( val = trimmed off = 0 len = 1 ) = `[` ).
+        node = parse_flow( trimmed ).
+      ELSE.
+        DATA lv_val  TYPE string.
+        DATA lv_null TYPE abap_bool.
+        resolve_scalar( EXPORTING raw = trimmed IMPORTING value = lv_val is_null = lv_null ).
+        node = lcl_tree=>new_scalar( value = lv_val is_null = lv_null ).
+      ENDIF.
     ELSEIF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
       node = parse_block( EXPORTING lines = lines CHANGING idx = idx ).
     ELSE.
       node = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
     ENDIF.
+  ENDMETHOD.
+
+  METHOD resolve_scalar.
+    is_null = abap_false.
+    value   = ``.
+    DATA(len) = strlen( raw ).
+    IF len = 0 OR raw = `~`.
+      is_null = abap_true.
+      RETURN.
+    ENDIF.
+    DATA(first) = substring( val = raw off = 0 len = 1 ).
+    IF first = `'`.
+      " single-quoted: strip outer quotes, '' → '
+      IF len < 2 OR substring( val = raw off = len - 1 len = 1 ) <> `'`.
+        RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+          EXPORTING value = `Unterminated single-quoted scalar`.
+      ENDIF.
+      DATA(inner) = substring( val = raw off = 1 len = len - 2 ).
+      REPLACE ALL OCCURRENCES OF `''` IN inner WITH `'`.
+      value = inner.
+    ELSEIF first = `"`.
+      " double-quoted: strip outer quotes, process escape sequences
+      IF len < 2 OR substring( val = raw off = len - 1 len = 1 ) <> `"`.
+        RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+          EXPORTING value = `Unterminated double-quoted scalar`.
+      ENDIF.
+      DATA(src)  = substring( val = raw off = 1 len = len - 2 ).
+      DATA(res)  = ``.
+      DATA(i)    = 0.
+      DATA(slen) = strlen( src ).
+      WHILE i < slen.
+        DATA(c) = substring( val = src off = i len = 1 ).
+        IF c = `\` AND i + 1 < slen.
+          DATA(esc) = substring( val = src off = i + 1 len = 1 ).
+          CASE esc.
+            WHEN `n`.  res = res && cl_abap_char_utilities=>newline.        i = i + 2.
+            WHEN `t`.  res = res && cl_abap_char_utilities=>horizontal_tab. i = i + 2.
+            WHEN `"`.  res = res && `"`.  i = i + 2.
+            WHEN `\`.  res = res && `\`.  i = i + 2.
+            WHEN `u`.
+              IF i + 5 < slen.
+                DATA(hex4) = substring( val = src off = i + 2 len = 4 ).
+                res = res && cl_abap_conv_in_ce=>uccp( hex4 ).
+                i = i + 6.
+              ELSE.
+                res = res && `\` && esc. i = i + 2.
+              ENDIF.
+            WHEN OTHERS. res = res && esc. i = i + 2.
+          ENDCASE.
+        ELSE.
+          res = res && c.
+          i = i + 1.
+        ENDIF.
+      ENDWHILE.
+      value = res.
+    ELSE.
+      " plain scalar — as-is
+      value = raw.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD parse_flow.
+    " Tokenize a flow collection {k:v,...} or [v,...] respecting nesting + quotes
+    DATA(len) = strlen( raw ).
+    IF len < 2.
+      RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+        EXPORTING value = `Invalid flow collection`.
+    ENDIF.
+    DATA(opener) = substring( val = raw off = 0 len = 1 ).
+    DATA(closer) = substring( val = raw off = len - 1 len = 1 ).
+    DATA lv_is_map TYPE abap_bool.
+    IF opener = `{` AND closer = `}`.
+      lv_is_map = abap_true.
+      node = lcl_tree=>new_collection( c_node=>mapping ).
+    ELSEIF opener = `[` AND closer = `]`.
+      node = lcl_tree=>new_collection( c_node=>sequence ).
+    ELSE.
+      RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+        EXPORTING value = `Invalid flow collection`.
+    ENDIF.
+
+    " split inner body on ',' at depth 0, respecting quotes and nesting
+    DATA(body) = substring( val = raw off = 1 len = len - 2 ).
+    DATA tokens    TYPE string_table.
+    DATA cur_tok   TYPE string VALUE ``.
+    DATA depth     TYPE i VALUE 0.
+    DATA in_sq     TYPE abap_bool VALUE abap_false.
+    DATA in_dq     TYPE abap_bool VALUE abap_false.
+    DATA(blen)     = strlen( body ).
+    DATA j         TYPE i VALUE 0.
+    WHILE j < blen.
+      DATA(bc) = substring( val = body off = j len = 1 ).
+      IF in_sq = abap_true.
+        cur_tok = cur_tok && bc.
+        IF bc = `'` AND j + 1 < blen AND substring( val = body off = j + 1 len = 1 ) = `'`.
+          cur_tok = cur_tok && `'`.
+          j = j + 2.
+          CONTINUE.
+        ENDIF.
+        IF bc = `'`. in_sq = abap_false. ENDIF.
+      ELSEIF in_dq = abap_true.
+        IF bc = `\` AND j + 1 < blen.
+          cur_tok = cur_tok && bc && substring( val = body off = j + 1 len = 1 ).
+          j = j + 2.
+          CONTINUE.
+        ENDIF.
+        cur_tok = cur_tok && bc.
+        IF bc = `"`. in_dq = abap_false. ENDIF.
+      ELSE.
+        CASE bc.
+          WHEN `'`. in_sq = abap_true. cur_tok = cur_tok && bc.
+          WHEN `"`. in_dq = abap_true. cur_tok = cur_tok && bc.
+          WHEN `{` OR `[`. depth = depth + 1. cur_tok = cur_tok && bc.
+          WHEN `}` OR `]`. depth = depth - 1. cur_tok = cur_tok && bc.
+          WHEN `,`.
+            IF depth = 0.
+              APPEND cur_tok TO tokens.
+              CLEAR cur_tok.
+            ELSE.
+              cur_tok = cur_tok && bc.
+            ENDIF.
+          WHEN OTHERS.
+            cur_tok = cur_tok && bc.
+        ENDCASE.
+      ENDIF.
+      j = j + 1.
+    ENDWHILE.
+    APPEND cur_tok TO tokens.
+
+    " process each token
+    LOOP AT tokens INTO DATA(tok).
+      DATA(trimmed) = condense( tok ).
+      CHECK trimmed IS NOT INITIAL.
+      IF lv_is_map = abap_true.
+        " find ':' at depth 0, not in quotes
+        DATA entry_key TYPE string VALUE ``.
+        DATA entry_val TYPE string VALUE ``.
+        DATA k         TYPE i VALUE 0.
+        DATA(tlen)     = strlen( trimmed ).
+        DATA fc        TYPE abap_bool VALUE abap_false.
+        DATA tsq       TYPE abap_bool VALUE abap_false.
+        DATA tdq       TYPE abap_bool VALUE abap_false.
+        DATA tdepth    TYPE i VALUE 0.
+        WHILE k < tlen.
+          DATA(tc) = substring( val = trimmed off = k len = 1 ).
+          IF tsq = abap_true.
+            IF tc = `'` AND k + 1 < tlen AND substring( val = trimmed off = k + 1 len = 1 ) = `'`.
+              k = k + 2. CONTINUE.
+            ENDIF.
+            IF tc = `'`. tsq = abap_false. ENDIF.
+          ELSEIF tdq = abap_true.
+            IF tc = `\` AND k + 1 < tlen. k = k + 2. CONTINUE. ENDIF.
+            IF tc = `"`. tdq = abap_false. ENDIF.
+          ELSE.
+            CASE tc.
+              WHEN `'`. tsq = abap_true.
+              WHEN `"`. tdq = abap_true.
+              WHEN `{` OR `[`. tdepth = tdepth + 1.
+              WHEN `}` OR `]`. tdepth = tdepth - 1.
+              WHEN `:`.
+                IF tdepth = 0.
+                  IF k + 1 >= tlen OR substring( val = trimmed off = k + 1 len = 1 ) = ` `.
+                    entry_key = substring( val = trimmed len = k ).
+                    DATA ks TYPE i.
+                    ks = k + 2.
+                    IF ks < tlen.
+                      entry_val = substring( val = trimmed off = ks ).
+                    ENDIF.
+                    fc = abap_true.
+                    EXIT.
+                  ENDIF.
+                ENDIF.
+            ENDCASE.
+          ENDIF.
+          k = k + 1.
+        ENDWHILE.
+        IF fc = abap_false.
+          entry_key = trimmed.
+        ENDIF.
+        DATA ev TYPE string.
+        DATA en TYPE abap_bool.
+        resolve_scalar( EXPORTING raw = condense( entry_val ) IMPORTING value = ev is_null = en ).
+        lcl_tree=>add_child( node = node key = condense( entry_key )
+                             child = lcl_tree=>new_scalar( value = ev is_null = en ) ).
+      ELSE.
+        " sequence item
+        DATA(fc1) = substring( val = trimmed off = 0 len = 1 ).
+        IF fc1 = `{` OR fc1 = `[`.
+          lcl_tree=>add_child( node = node child = parse_flow( trimmed ) ).
+        ELSE.
+          DATA sv TYPE string.
+          DATA sn TYPE abap_bool.
+          resolve_scalar( EXPORTING raw = trimmed IMPORTING value = sv is_null = sn ).
+          lcl_tree=>add_child( node = node child = lcl_tree=>new_scalar( value = sv is_null = sn ) ).
+        ENDIF.
+      ENDIF.
+    ENDLOOP.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -821,6 +821,16 @@ CLASS lcl_typed_mapper IMPLEMENTATION.
               ENDIF.
             ENDLOOP.
           ENDIF.
+          IF lv_compname IS INITIAL AND pretty_name <> z_ui2_yaml=>pretty_mode-none.
+            " pretty_name active: try inverse transform (myField → MY_FIELD)
+            DATA(inv_key) = pretty_inverse( yaml_key = child-key pretty_name = pretty_name ).
+            LOOP AT sd->components INTO comp.
+              IF comp-name = inv_key.
+                lv_compname = comp-name.
+                EXIT.
+              ENDIF.
+            ENDLOOP.
+          ENDIF.
           CHECK lv_compname IS NOT INITIAL.
           " assign component via field-symbol
           ASSIGN COMPONENT lv_compname OF STRUCTURE data TO FIELD-SYMBOL(<comp_data>).
@@ -885,6 +895,28 @@ CLASS lcl_typed_mapper IMPLEMENTATION.
       WHEN OTHERS.
         " reference, object, etc. — skip
     ENDCASE.
+  ENDMETHOD.
+
+  METHOD pretty_inverse.
+    " Invert pretty_name transform: camel/pascal/extended → insert '_' before interior uppercase, then TO_UPPER.
+    " none/low_case: just TO_UPPER.
+    IF pretty_name = z_ui2_yaml=>pretty_mode-none OR pretty_name = z_ui2_yaml=>pretty_mode-low_case.
+      abap_name = to_upper( yaml_key ).
+      RETURN.
+    ENDIF.
+    DATA(len) = strlen( yaml_key ).
+    DATA lv_out TYPE string.
+    DATA i TYPE i.
+    WHILE i < len.
+      DATA(c) = substring( val = yaml_key off = i len = 1 ).
+      IF i > 0 AND c CA `ABCDEFGHIJKLMNOPQRSTUVWXYZ`.
+        lv_out = lv_out && `_` && c.
+      ELSE.
+        lv_out = lv_out && c.
+      ENDIF.
+      i = i + 1.
+    ENDWHILE.
+    abap_name = to_upper( lv_out ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -1,0 +1,23 @@
+*"* use this source file for the implementation part of
+*"* local helper classes
+
+CLASS c_node IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lcl_node_ref IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lcl_scanner IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lcl_parser IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lcl_typed_mapper IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lcl_gen_mapper IMPLEMENTATION.
+ENDCLASS.
+
+CLASS lcl_emitter IMPLEMENTATION.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -49,53 +49,26 @@ CLASS lcl_scanner IMPLEMENTATION.
     raw[ sentinel_idx ] = COND string( WHEN slen0 > 0
                                        THEN substring( val = sentinel_val len = slen0 - 1 )
                                        ELSE `` ).
-    DATA total    TYPE i.
-    DATA n        TYPE i.
-    DATA rr       TYPE string.
-    DATA rlen     TYPE i.
-    DATA off      TYPE i.
-    DATA indent   TYPE i.
-    DATA body     TYPE string.
-    DATA blen     TYPE i.
-    DATA blk_ind  TYPE string.
-    DATA last2c   TYPE string.
-    DATA last1c   TYPE string.
-    DATA ind_len  TYPE i.
-    DATA pre_char TYPE string.
-    DATA blk_key0 TYPE string.
-    DATA bk_len   TYPE i.
-    DATA line     TYPE ty_line.
+    DATA total        TYPE i.
+    DATA n            TYPE i.
+    DATA lv_raw_line  TYPE string.
+    DATA rlen         TYPE i.
+    DATA off          TYPE i.
+    DATA indent       TYPE i.
+    DATA body         TYPE string.
+    DATA blen         TYPE i.
+    DATA blk_scalar_ind TYPE string.
+    DATA last2c       TYPE string.
+    DATA last1c       TYPE string.
+    DATA ind_len      TYPE i.
+    DATA pre_char     TYPE string.
+    DATA blk_key0     TYPE string.
+    DATA bk_len       TYPE i.
+    DATA line         TYPE ty_line.
 
-    " Block-body collection work vars
+    " Block-body collection work vars (passed to collect_block_body)
     DATA blk_body     TYPE string_table.
-    DATA nn           TYPE i.
-    DATA bbrr         TYPE string.
-    DATA bb_off       TYPE i.
-    DATA bb_len       TYPE i.
-    DATA bb_blank     TYPE abap_bool.
-
-    " Block indent detection
-    DATA blk_ind_col   TYPE i.
-    DATA blk_stripped  TYPE string_table.
-    DATA bsl           TYPE string.
-    DATA bsl_off       TYPE i.
-    DATA bsl_len       TYPE i.
-    DATA strip_from    TYPE i.
-    DATA trailing_blanks TYPE i.
-    DATA tot_stripped  TYPE i.
-    DATA ti            TYPE i.
-    DATA content_lines TYPE i.
-
-    " Block value assembly
-    DATA blk_style TYPE string.
-    DATA blk_chomp TYPE string.
-    DATA blk_val   TYPE string.
-    DATA li        TYPE i.
-    DATA fi        TYPE i.
-    DATA fl        TYPE string.
-    DATA prev_blank TYPE abap_bool.
-    DATA ki        TYPE i.
-    DATA bv_len    TYPE i.
+    DATA lv_next_n    TYPE i.
 
     " Anchor detection on block-scalar header
     DATA blk_colon_pos   TYPE i.
@@ -106,17 +79,17 @@ CLASS lcl_scanner IMPLEMENTATION.
     total = lines( raw ).
     n     = 1.
     WHILE n <= total.
-      rr   = raw[ n ].
+      lv_raw_line   = raw[ n ].
       " strip trailing CR so CRLF input is handled identically to LF
-      DATA(rr_len) = strlen( rr ).
-      IF rr_len > 0 AND substring( val = rr off = rr_len - 1 len = 1 ) = cl_abap_char_utilities=>cr_lf(1).
-        rr = substring( val = rr len = rr_len - 1 ).
+      DATA(rr_len) = strlen( lv_raw_line ).
+      IF rr_len > 0 AND substring( val = lv_raw_line off = rr_len - 1 len = 1 ) = cl_abap_char_utilities=>cr_lf(1).
+        lv_raw_line = substring( val = lv_raw_line len = rr_len - 1 ).
       ENDIF.
-      rlen = strlen( rr ).
+      rlen = strlen( lv_raw_line ).
       off  = 0.
       " count leading spaces; reject tab in leading whitespace
       WHILE off < rlen.
-        CASE substring( val = rr off = off len = 1 ).
+        CASE substring( val = lv_raw_line off = off len = 1 ).
           WHEN ` `.
             off = off + 1.
           WHEN cl_abap_char_utilities=>horizontal_tab.
@@ -128,7 +101,7 @@ CLASS lcl_scanner IMPLEMENTATION.
         ENDCASE.
       ENDWHILE.
       indent = off.
-      body   = substring( val = rr off = off ).
+      body   = substring( val = lv_raw_line off = off ).
       body   = strip_comment( body ).
       body   = trim_right( body ).
       IF body IS INITIAL OR body = `---`.
@@ -147,23 +120,23 @@ CLASS lcl_scanner IMPLEMENTATION.
       ENDIF.
 
       " Detect block scalar indicator: |, >, |-, |+, >-, >+
-      blen    = strlen( body ).
-      blk_ind = ``.
+      blen          = strlen( body ).
+      blk_scalar_ind = ``.
       IF blen >= 2.
         last2c = substring( val = body off = blen - 2 len = 2 ).
         IF last2c = `|-` OR last2c = `|+` OR last2c = `>-` OR last2c = `>+`.
-          blk_ind = last2c.
+          blk_scalar_ind = last2c.
         ENDIF.
       ENDIF.
-      IF blk_ind IS INITIAL AND blen >= 1.
+      IF blk_scalar_ind IS INITIAL AND blen >= 1.
         last1c = substring( val = body off = blen - 1 len = 1 ).
         IF last1c = `|` OR last1c = `>`.
-          blk_ind = last1c.
+          blk_scalar_ind = last1c.
         ENDIF.
       ENDIF.
 
-      IF blk_ind IS NOT INITIAL.
-        ind_len  = strlen( blk_ind ).
+      IF blk_scalar_ind IS NOT INITIAL.
+        ind_len  = strlen( blk_scalar_ind ).
         " pre_char: the character just before the indicator
         pre_char = COND string( WHEN blen > ind_len
                                 THEN substring( val = body off = blen - ind_len - 1 len = 1 )
@@ -195,138 +168,149 @@ CLASS lcl_scanner IMPLEMENTATION.
            AND bk_len > 0
            AND substring( val = blk_key0 off = bk_len - 1 len = 1 ) = `:`.
 
-          " Collect raw body lines: blank OR indent > header indent
-          CLEAR blk_body.
-          nn = n + 1.
-          WHILE nn <= total.
-            bbrr   = raw[ nn ].
-            bb_len = strlen( bbrr ).
-            bb_off = 0.
-            WHILE bb_off < bb_len AND substring( val = bbrr off = bb_off len = 1 ) = ` `.
-              bb_off = bb_off + 1.
-            ENDWHILE.
-            bb_blank = xsdbool( bb_off = bb_len ).
-            IF bb_blank = abap_true.
-              APPEND bbrr TO blk_body.
-              nn = nn + 1.
-            ELSEIF bb_off > indent.
-              APPEND bbrr TO blk_body.
-              nn = nn + 1.
-            ELSE.
-              EXIT.
-            ENDIF.
-          ENDWHILE.
+          collect_block_body( EXPORTING raw     = raw
+                                        start_n = n
+                                        indent  = indent
+                                        total   = total
+                              IMPORTING rt_body   = blk_body
+                                        rv_next_n = lv_next_n ).
 
-          " Block indent = indent of first non-blank body line
-          blk_ind_col = 0.
-          LOOP AT blk_body INTO bsl.
-            bsl_off = 0.
-            bsl_len = strlen( bsl ).
-            WHILE bsl_off < bsl_len AND substring( val = bsl off = bsl_off len = 1 ) = ` `.
-              bsl_off = bsl_off + 1.
-            ENDWHILE.
-            IF bsl_off < bsl_len.
-              blk_ind_col = bsl_off.
-              EXIT.
-            ENDIF.
-          ENDLOOP.
-
-          " Strip block indent from each body line
-          CLEAR blk_stripped.
-          LOOP AT blk_body INTO bsl.
-            bsl_off = 0.
-            bsl_len = strlen( bsl ).
-            WHILE bsl_off < bsl_len AND substring( val = bsl off = bsl_off len = 1 ) = ` `.
-              bsl_off = bsl_off + 1.
-            ENDWHILE.
-            IF bsl_off = bsl_len.
-              APPEND `` TO blk_stripped.
-            ELSE.
-              strip_from = COND i( WHEN bsl_off >= blk_ind_col THEN blk_ind_col ELSE bsl_off ).
-              APPEND substring( val = bsl off = strip_from ) TO blk_stripped.
-            ENDIF.
-          ENDLOOP.
-
-          " Count trailing blank lines
-          tot_stripped   = lines( blk_stripped ).
-          trailing_blanks = 0.
-          ti = tot_stripped.
-          WHILE ti >= 1 AND blk_stripped[ ti ] IS INITIAL.
-            trailing_blanks = trailing_blanks + 1.
-            ti = ti - 1.
-          ENDWHILE.
-          content_lines = tot_stripped - trailing_blanks.
-
-          " Fold/join body lines
-          blk_style = substring( val = blk_ind off = 0 len = 1 ).
-          blk_chomp = COND string( WHEN ind_len > 1
-                                   THEN substring( val = blk_ind off = 1 len = 1 )
-                                   ELSE `` ).
-          blk_val = ``.
-          IF blk_style = `|`.
-            " LITERAL: each content line + LF
-            li = 1.
-            WHILE li <= content_lines.
-              blk_val = blk_val && blk_stripped[ li ] && cl_abap_char_utilities=>newline.
-              li = li + 1.
-            ENDWHILE.
-          ELSE.
-            " FOLDED: consecutive non-blank lines joined by space; blank line → LF
-            prev_blank = abap_false.
-            fi = 1.
-            WHILE fi <= content_lines.
-              fl = blk_stripped[ fi ].
-              IF fl IS INITIAL.
-                blk_val    = blk_val && cl_abap_char_utilities=>newline.
-                prev_blank = abap_true.
-              ELSE.
-                IF fi > 1 AND prev_blank = abap_false.
-                  blk_val = blk_val && ` `.
-                ENDIF.
-                blk_val    = blk_val && fl.
-                prev_blank = abap_false.
-              ENDIF.
-              fi = fi + 1.
-            ENDWHILE.
-            IF content_lines > 0.
-              blk_val = blk_val && cl_abap_char_utilities=>newline.
-            ENDIF.
-          ENDIF.
-
-          " Apply chomping
-          CASE blk_chomp.
-            WHEN `-`.
-              " STRIP: remove trailing LF
-              bv_len = strlen( blk_val ).
-              IF bv_len > 0 AND
-                 substring( val = blk_val off = bv_len - 1 len = 1 ) = cl_abap_char_utilities=>newline.
-                blk_val = substring( val = blk_val len = bv_len - 1 ).
-              ENDIF.
-            WHEN `+`.
-              " KEEP: append trailing blank lines as extra LFs
-              ki = 1.
-              WHILE ki <= trailing_blanks.
-                blk_val = blk_val && cl_abap_char_utilities=>newline.
-                ki = ki + 1.
-              ENDWHILE.
-            WHEN OTHERS.
-              " CLIP (default): exactly one trailing LF already emitted — nothing to do
-          ENDCASE.
-
+          line-blk_value = assemble_block_value( blk_body       = blk_body
+                                                 blk_scalar_ind = blk_scalar_ind ).
           line-blk_scalar_hd = abap_true.
-          line-blk_value     = blk_val.
           line-content       = blk_key0.
           APPEND line TO lines.
-          n = nn.
+          n = lv_next_n.
           CONTINUE.
         ELSE.
-          CLEAR blk_ind.  " not a mapping block header — treat as plain content
+          CLEAR blk_scalar_ind.  " not a mapping block header — treat as plain content
         ENDIF.
       ENDIF.
 
       APPEND line TO lines.
       n = n + 1.
     ENDWHILE.
+  ENDMETHOD.
+
+  METHOD collect_block_body.
+    " Collect raw body lines from raw[start_n+1..]: blank lines or indent > header indent.
+    " Returns collected lines in rt_body; rv_next_n = first line NOT consumed.
+    rv_next_n = start_n + 1.
+    WHILE rv_next_n <= total.
+      DATA(lv_line) = raw[ rv_next_n ].
+      DATA(bb_len)  = strlen( lv_line ).
+      DATA(bb_off)  = 0.
+      WHILE bb_off < bb_len AND substring( val = lv_line off = bb_off len = 1 ) = ` `.
+        bb_off = bb_off + 1.
+      ENDWHILE.
+      IF bb_off = bb_len OR bb_off > indent.
+        APPEND lv_line TO rt_body.
+        rv_next_n = rv_next_n + 1.
+      ELSE.
+        EXIT.
+      ENDIF.
+    ENDWHILE.
+  ENDMETHOD.
+
+  METHOD assemble_block_value.
+    " Detect block indent, strip it, fold/literal join, apply chomping.
+    " blk_scalar_ind: first char = style ('|' literal / '>' folded), second = chomp ('-'/'+'/none).
+
+    " Block indent = indent of first non-blank body line
+    DATA blk_ind_col TYPE i.
+    LOOP AT blk_body INTO DATA(lv_ln).
+      DATA(bsl_off) = 0.
+      DATA(bsl_len) = strlen( lv_ln ).
+      WHILE bsl_off < bsl_len AND substring( val = lv_ln off = bsl_off len = 1 ) = ` `.
+        bsl_off = bsl_off + 1.
+      ENDWHILE.
+      IF bsl_off < bsl_len.
+        blk_ind_col = bsl_off.
+        EXIT.
+      ENDIF.
+    ENDLOOP.
+
+    " Strip block indent from each body line
+    DATA blk_stripped TYPE string_table.
+    LOOP AT blk_body INTO lv_ln.
+      bsl_off = 0.
+      bsl_len = strlen( lv_ln ).
+      WHILE bsl_off < bsl_len AND substring( val = lv_ln off = bsl_off len = 1 ) = ` `.
+        bsl_off = bsl_off + 1.
+      ENDWHILE.
+      IF bsl_off = bsl_len.
+        APPEND `` TO blk_stripped.
+      ELSE.
+        DATA(strip_from) = COND i( WHEN bsl_off >= blk_ind_col THEN blk_ind_col ELSE bsl_off ).
+        APPEND substring( val = lv_ln off = strip_from ) TO blk_stripped.
+      ENDIF.
+    ENDLOOP.
+
+    " Count trailing blank lines
+    DATA(tot_stripped)    = lines( blk_stripped ).
+    DATA trailing_blanks  TYPE i.
+    DATA(ti)              = tot_stripped.
+    WHILE ti >= 1 AND blk_stripped[ ti ] IS INITIAL.
+      trailing_blanks = trailing_blanks + 1.
+      ti = ti - 1.
+    ENDWHILE.
+    DATA(content_lines) = tot_stripped - trailing_blanks.
+
+    " Fold/join body lines
+    DATA(blk_style) = substring( val = blk_scalar_ind off = 0 len = 1 ).
+    DATA(ind_len)   = strlen( blk_scalar_ind ).
+    DATA(blk_chomp) = COND string( WHEN ind_len > 1
+                                   THEN substring( val = blk_scalar_ind off = 1 len = 1 )
+                                   ELSE `` ).
+    IF blk_style = `|`.
+      " LITERAL: each content line + LF
+      DATA(li) = 1.
+      WHILE li <= content_lines.
+        rv_val = rv_val && blk_stripped[ li ] && cl_abap_char_utilities=>newline.
+        li = li + 1.
+      ENDWHILE.
+    ELSE.
+      " FOLDED: consecutive non-blank lines joined by space; blank line → LF
+      DATA prev_blank TYPE abap_bool.
+      DATA(fi) = 1.
+      WHILE fi <= content_lines.
+        DATA(fl) = blk_stripped[ fi ].
+        IF fl IS INITIAL.
+          rv_val     = rv_val && cl_abap_char_utilities=>newline.
+          prev_blank = abap_true.
+        ELSE.
+          IF fi > 1 AND prev_blank = abap_false.
+            rv_val = rv_val && ` `.
+          ENDIF.
+          rv_val     = rv_val && fl.
+          prev_blank = abap_false.
+        ENDIF.
+        fi = fi + 1.
+      ENDWHILE.
+      IF content_lines > 0.
+        rv_val = rv_val && cl_abap_char_utilities=>newline.
+      ENDIF.
+    ENDIF.
+
+    " Apply chomping
+    CASE blk_chomp.
+      WHEN `-`.
+        " STRIP: remove trailing LF
+        DATA(bv_len) = strlen( rv_val ).
+        IF bv_len > 0 AND
+           substring( val = rv_val off = bv_len - 1 len = 1 ) = cl_abap_char_utilities=>newline.
+          rv_val = substring( val = rv_val len = bv_len - 1 ).
+        ENDIF.
+      WHEN `+`.
+        " KEEP: append trailing blank lines as extra LFs
+        DATA(ki) = 1.
+        WHILE ki <= trailing_blanks.
+          rv_val = rv_val && cl_abap_char_utilities=>newline.
+          ki = ki + 1.
+        ENDWHILE.
+      WHEN OTHERS.
+        " CLIP (default): exactly one trailing LF already emitted — nothing to do
+    ENDCASE.
   ENDMETHOD.
 
   METHOD strip_comment.
@@ -608,6 +592,7 @@ CLASS lcl_parser IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD value_or_block.
+    DATA aname TYPE string.
     IF has_inline = abap_true.
       " trim leading/trailing only — preserve internal spaces in quoted scalars
       DATA(trimmed) = lcl_scanner=>trim( inline_value ).
@@ -621,12 +606,11 @@ CLASS lcl_parser IMPLEMENTATION.
         RETURN.
       ENDIF.
       " strip anchor prefix — trimmed may become empty if anchor was the only inline content
-      DATA(aname) = strip_anchor( CHANGING raw = trimmed ).
+      aname = strip_anchor( CHANGING raw = trimmed ).
       IF trimmed IS NOT INITIAL.
         " inline value exists after optional anchor
-        IF strlen( trimmed ) > 0 AND
-           ( substring( val = trimmed off = 0 len = 1 ) = `{` OR
-             substring( val = trimmed off = 0 len = 1 ) = `[` ).
+        IF substring( val = trimmed off = 0 len = 1 ) = `{`
+           OR substring( val = trimmed off = 0 len = 1 ) = `[`.
           node = parse_flow( trimmed ).
         ELSE.
           DATA lv_val  TYPE string.
@@ -784,13 +768,11 @@ CLASS lcl_parser IMPLEMENTATION.
     APPEND cur_tok TO tokens.
 
     " Declare map-branch work vars outside loop — ABAP DATA VALUE init is method-scope, not loop-scope
-    DATA entry_key TYPE string.
-    DATA entry_val TYPE string.
-    DATA k         TYPE i.
-    DATA fc        TYPE abap_bool.
-    DATA tsq       TYPE abap_bool.
-    DATA tdq       TYPE abap_bool.
-    DATA tdepth    TYPE i.
+    " in_sq / in_dq / depth are reused from the tokenizer loop above (same method scope)
+    DATA entry_key       TYPE string.
+    DATA entry_val       TYPE string.
+    DATA k               TYPE i.
+    DATA lv_colon_found  TYPE abap_bool.
 
     " process each token
     LOOP AT tokens INTO DATA(tok).
@@ -798,35 +780,35 @@ CLASS lcl_parser IMPLEMENTATION.
       CHECK trimmed IS NOT INITIAL.
       IF lv_is_map = abap_true.
         " reset per-entry work vars each iteration — DATA VALUE is method-scope, not loop-scope
-        CLEAR: entry_key, entry_val, fc, tsq, tdq, tdepth.
+        CLEAR: entry_key, entry_val, lv_colon_found, in_sq, in_dq, depth.
         k = 0.
         " find ':' at depth 0, not in quotes
         DATA(tlen) = strlen( trimmed ).
         WHILE k < tlen.
           DATA(tc) = substring( val = trimmed off = k len = 1 ).
-          IF tsq = abap_true.
+          IF in_sq = abap_true.
             IF tc = `'` AND k + 1 < tlen AND substring( val = trimmed off = k + 1 len = 1 ) = `'`.
               k = k + 2. CONTINUE.
             ENDIF.
-            IF tc = `'`. tsq = abap_false. ENDIF.
-          ELSEIF tdq = abap_true.
+            IF tc = `'`. in_sq = abap_false. ENDIF.
+          ELSEIF in_dq = abap_true.
             IF tc = `\` AND k + 1 < tlen. k = k + 2. CONTINUE. ENDIF.
-            IF tc = `"`. tdq = abap_false. ENDIF.
+            IF tc = `"`. in_dq = abap_false. ENDIF.
           ELSE.
             CASE tc.
-              WHEN `'`. tsq = abap_true.
-              WHEN `"`. tdq = abap_true.
-              WHEN `{` OR `[`. tdepth = tdepth + 1.
-              WHEN `}` OR `]`. tdepth = tdepth - 1.
+              WHEN `'`. in_sq = abap_true.
+              WHEN `"`. in_dq = abap_true.
+              WHEN `{` OR `[`. depth = depth + 1.
+              WHEN `}` OR `]`. depth = depth - 1.
               WHEN `:`.
-                IF tdepth = 0.
+                IF depth = 0.
                   IF k + 1 >= tlen OR substring( val = trimmed off = k + 1 len = 1 ) = ` `.
                     entry_key = substring( val = trimmed len = k ).
                     DATA(ks) = k + 2.
                     IF ks < tlen.
                       entry_val = substring( val = trimmed off = ks ).
                     ENDIF.
-                    fc = abap_true.
+                    lv_colon_found = abap_true.
                     EXIT.
                   ENDIF.
                 ENDIF.
@@ -834,7 +816,7 @@ CLASS lcl_parser IMPLEMENTATION.
           ENDIF.
           k = k + 1.
         ENDWHILE.
-        IF fc = abap_false.
+        IF lv_colon_found = abap_false.
           entry_key = trimmed.
         ENDIF.
         " dispatch map value: nested collection or scalar
@@ -1042,7 +1024,7 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
     DATA(len)    = strlen( raw_up ).
     DATA lv_out  TYPE string.
     DATA i       TYPE i.
-    WHILE i < len AND strlen( lv_out ) < 30.
+    WHILE i < len AND strlen( lv_out ) < c_max_comp_name_len.
       DATA(c) = substring( val = raw_up off = i len = 1 ).
       IF c CO `ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_`.
         lv_out = lv_out && c.
@@ -1054,7 +1036,7 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
     IF lv_out IS INITIAL.
       lv_out = `F`.
     ELSEIF substring( val = lv_out off = 0 len = 1 ) CO `0123456789`.
-      lv_out = `F` && substring( val = lv_out len = COND i( WHEN strlen( lv_out ) < 30 THEN strlen( lv_out ) ELSE 29 ) ).
+      lv_out = `F` && substring( val = lv_out len = COND i( WHEN strlen( lv_out ) < c_max_comp_name_len THEN strlen( lv_out ) ELSE c_max_comp_name_len - 1 ) ).
     ENDIF.
     result = lv_out.
   ENDMETHOD.
@@ -1179,7 +1161,7 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
             lv_sfxs = |_{ lv_sfx }|.
             lv_sfxl = strlen( lv_sfxs ).
             lv_basl = strlen( base_name ).
-            lv_triml = COND i( WHEN lv_basl + lv_sfxl > 30 THEN 30 - lv_sfxl ELSE lv_basl ).
+            lv_triml = COND i( WHEN lv_basl + lv_sfxl > c_max_comp_name_len THEN c_max_comp_name_len - lv_sfxl ELSE lv_basl ).
             lv_final = substring( val = base_name len = lv_triml ) && lv_sfxs.
           ENDWHILE.
           INSERT lv_final INTO TABLE lt_used.
@@ -1470,7 +1452,7 @@ CLASS lcl_emitter IMPLEMENTATION.
     DATA(len) = strlen( value ).
 
     " always-double mode
-    IF quote_style = 'D'.
+    IF quote_style = z_ui2_yaml=>quote_mode-always_double.
       result = `"` && escape_dq( value ) && `"`.
       RETURN.
     ENDIF.
@@ -1582,7 +1564,6 @@ CLASS lcl_emitter IMPLEMENTATION.
     ENDWHILE.
     DATA lines_t TYPE string_table.
     SPLIT text AT cl_abap_char_utilities=>newline INTO TABLE lines_t.
-    DATA lv_last TYPE i VALUE 0.
     " detect trailing newline: if text ends with NL, last token is empty
     DATA(tlen) = strlen( text ).
     DATA lv_has_trail TYPE abap_bool.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -91,6 +91,11 @@ CLASS lcl_scanner IMPLEMENTATION.
     n     = 1.
     WHILE n <= total.
       rr   = raw[ n ].
+      " strip trailing CR so CRLF input is handled identically to LF
+      DATA(rr_len) = strlen( rr ).
+      IF rr_len > 0 AND substring( val = rr off = rr_len - 1 len = 1 ) = cl_abap_char_utilities=>cr_lf(1).
+        rr = substring( val = rr len = rr_len - 1 ).
+      ENDIF.
       rlen = strlen( rr ).
       off  = 0.
       " count leading spaces; reject tab in leading whitespace
@@ -506,7 +511,14 @@ CLASS lcl_parser IMPLEMENTATION.
     "   following:   continuation lines with indent > own_indent, copied as-is
     DATA sub TYPE ty_lines.
     IF rest IS NOT INITIAL.
-      APPEND VALUE ty_line( lineno = 0 indent = own_indent + 2 content = rest ) TO sub.
+      " Determine actual continuation indent: first real continuation line, or own_indent+2 fallback
+      DATA lv_first_cont_indent TYPE i.
+      IF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
+        lv_first_cont_indent = lines[ idx ]-indent.
+      ELSE.
+        lv_first_cont_indent = own_indent + 2.
+      ENDIF.
+      APPEND VALUE ty_line( lineno = 0 indent = lv_first_cont_indent content = rest ) TO sub.
     ENDIF.
     WHILE idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
       APPEND lines[ idx ] TO sub.
@@ -673,8 +685,12 @@ CLASS lcl_parser IMPLEMENTATION.
       ENDWHILE.
       value = res.
     ELSE.
-      " plain scalar — as-is
-      value = raw.
+      " plain scalar — check for YAML 1.2 null keywords before treating as-is
+      IF raw = `null` OR raw = `Null` OR raw = `NULL`.
+        is_null = abap_true.
+      ELSE.
+        value = raw.
+      ENDIF.
     ENDIF.
   ENDMETHOD.
 
@@ -944,7 +960,8 @@ CLASS lcl_typed_mapper IMPLEMENTATION.
       WHEN cl_abap_typedescr=>kind_elem.
         " scalar → elementary
         IF node->node-is_null = abap_true.
-          RETURN.  " leave initial
+          CLEAR data.  " null node → reset to initial
+          RETURN.
         ENDIF.
         " bool target: map true/false/x → abap_true/abap_false
         DATA(eld2) = CAST cl_abap_elemdescr( td ).
@@ -1326,7 +1343,7 @@ CLASS lcl_emitter IMPLEMENTATION.
             DATA(first_line) = substring( val = row_s len = nl_pos ).
             DATA(rest_lines) = substring( val = row_s off = nl_pos + 1 ).
             result = result && `- ` && first_line && cl_abap_char_utilities=>newline
-                            && indent_block( text = rest_lines n = 2 ).
+                            && indent_block( text = rest_lines n = indent_step ).
           ELSE.
             result = result && `- ` && row_s.
           ENDIF.
@@ -1373,6 +1390,11 @@ CLASS lcl_emitter IMPLEMENTATION.
               AND substring( val = lv_raw off = strlen( lv_raw ) - 1 len = 1 ) = ` `.
               lv_raw = substring( val = lv_raw len = strlen( lv_raw ) - 1 ).
             ENDWHILE.
+            " TYPE p puts the minus sign on the right (e.g. "3.14-"); move it to the front
+            IF strlen( lv_raw ) > 0
+              AND substring( val = lv_raw off = strlen( lv_raw ) - 1 len = 1 ) = `-`.
+              lv_raw = `-` && substring( val = lv_raw len = strlen( lv_raw ) - 1 ).
+            ENDIF.
             result = lv_raw.
         ENDCASE.
 

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -75,6 +75,16 @@ CLASS lcl_scanner IMPLEMENTATION.
     ENDWHILE.
   ENDMETHOD.
 
+  METHOD trim.
+    " Leading/trailing whitespace only — does NOT collapse internal spaces
+    DATA(len) = strlen( val ).
+    DATA(l_off) = 0.
+    WHILE l_off < len AND substring( val = val off = l_off len = 1 ) = ` `.
+      l_off = l_off + 1.
+    ENDWHILE.
+    result = trim_right( substring( val = val off = l_off ) ).
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS lcl_parser IMPLEMENTATION.
@@ -230,7 +240,8 @@ CLASS lcl_parser IMPLEMENTATION.
 
   METHOD value_or_block.
     IF has_inline = abap_true.
-      DATA(trimmed) = condense( inline_value ).
+      " trim leading/trailing only — preserve internal spaces in quoted scalars
+      DATA(trimmed) = lcl_scanner=>trim( inline_value ).
       IF strlen( trimmed ) > 0 AND
          ( substring( val = trimmed off = 0 len = 1 ) = `{` OR
            substring( val = trimmed off = 0 len = 1 ) = `[` ).
@@ -258,7 +269,7 @@ CLASS lcl_parser IMPLEMENTATION.
     ENDIF.
     DATA(first) = substring( val = raw off = 0 len = 1 ).
     IF first = `'`.
-      " single-quoted: strip outer quotes, '' → '
+      " ponytail: last-char termination check; full inner walk if strict mode needed
       IF len < 2 OR substring( val = raw off = len - 1 len = 1 ) <> `'`.
         RAISE EXCEPTION TYPE cx_sy_conversion_no_number
           EXPORTING value = `Unterminated single-quoted scalar`.
@@ -277,8 +288,8 @@ CLASS lcl_parser IMPLEMENTATION.
       DATA(i)    = 0.
       DATA(slen) = strlen( src ).
       WHILE i < slen.
-        DATA(c) = substring( val = src off = i len = 1 ).
-        IF c = `\` AND i + 1 < slen.
+        DATA(cv) = substring( val = src off = i len = 1 ).
+        IF cv = `\` AND i + 1 < slen.
           DATA(esc) = substring( val = src off = i + 1 len = 1 ).
           CASE esc.
             WHEN `n`.  res = res && cl_abap_char_utilities=>newline.        i = i + 2.
@@ -296,7 +307,7 @@ CLASS lcl_parser IMPLEMENTATION.
             WHEN OTHERS. res = res && esc. i = i + 2.
           ENDCASE.
         ELSE.
-          res = res && c.
+          res = res && cv.
           i = i + 1.
         ENDIF.
       ENDWHILE.
@@ -328,14 +339,15 @@ CLASS lcl_parser IMPLEMENTATION.
     ENDIF.
 
     " split inner body on ',' at depth 0, respecting quotes and nesting
-    DATA(body) = substring( val = raw off = 1 len = len - 2 ).
-    DATA tokens    TYPE string_table.
-    DATA cur_tok   TYPE string VALUE ``.
-    DATA depth     TYPE i VALUE 0.
-    DATA in_sq     TYPE abap_bool VALUE abap_false.
-    DATA in_dq     TYPE abap_bool VALUE abap_false.
-    DATA(blen)     = strlen( body ).
-    DATA j         TYPE i VALUE 0.
+    DATA(body)  = substring( val = raw off = 1 len = len - 2 ).
+    DATA tokens TYPE string_table.
+    DATA cur_tok TYPE string.
+    DATA depth   TYPE i.
+    DATA in_sq   TYPE abap_bool.
+    DATA in_dq   TYPE abap_bool.
+    DATA(blen)   = strlen( body ).
+    DATA j       TYPE i.
+
     WHILE j < blen.
       DATA(bc) = substring( val = body off = j len = 1 ).
       IF in_sq = abap_true.
@@ -375,20 +387,25 @@ CLASS lcl_parser IMPLEMENTATION.
     ENDWHILE.
     APPEND cur_tok TO tokens.
 
+    " Declare map-branch work vars outside loop — ABAP DATA VALUE init is method-scope, not loop-scope
+    DATA entry_key TYPE string.
+    DATA entry_val TYPE string.
+    DATA k         TYPE i.
+    DATA fc        TYPE abap_bool.
+    DATA tsq       TYPE abap_bool.
+    DATA tdq       TYPE abap_bool.
+    DATA tdepth    TYPE i.
+
     " process each token
     LOOP AT tokens INTO DATA(tok).
-      DATA(trimmed) = condense( tok ).
+      DATA(trimmed) = lcl_scanner=>trim( tok ).
       CHECK trimmed IS NOT INITIAL.
       IF lv_is_map = abap_true.
+        " reset per-entry work vars each iteration — DATA VALUE is method-scope, not loop-scope
+        CLEAR: entry_key, entry_val, fc, tsq, tdq, tdepth.
+        k = 0.
         " find ':' at depth 0, not in quotes
-        DATA entry_key TYPE string VALUE ``.
-        DATA entry_val TYPE string VALUE ``.
-        DATA k         TYPE i VALUE 0.
-        DATA(tlen)     = strlen( trimmed ).
-        DATA fc        TYPE abap_bool VALUE abap_false.
-        DATA tsq       TYPE abap_bool VALUE abap_false.
-        DATA tdq       TYPE abap_bool VALUE abap_false.
-        DATA tdepth    TYPE i VALUE 0.
+        DATA(tlen) = strlen( trimmed ).
         WHILE k < tlen.
           DATA(tc) = substring( val = trimmed off = k len = 1 ).
           IF tsq = abap_true.
@@ -409,8 +426,7 @@ CLASS lcl_parser IMPLEMENTATION.
                 IF tdepth = 0.
                   IF k + 1 >= tlen OR substring( val = trimmed off = k + 1 len = 1 ) = ` `.
                     entry_key = substring( val = trimmed len = k ).
-                    DATA ks TYPE i.
-                    ks = k + 2.
+                    DATA(ks) = k + 2.
                     IF ks < tlen.
                       entry_val = substring( val = trimmed off = ks ).
                     ENDIF.
@@ -425,13 +441,22 @@ CLASS lcl_parser IMPLEMENTATION.
         IF fc = abap_false.
           entry_key = trimmed.
         ENDIF.
-        DATA ev TYPE string.
-        DATA en TYPE abap_bool.
-        resolve_scalar( EXPORTING raw = condense( entry_val ) IMPORTING value = ev is_null = en ).
-        lcl_tree=>add_child( node = node key = condense( entry_key )
-                             child = lcl_tree=>new_scalar( value = ev is_null = en ) ).
+        " dispatch map value: nested collection or scalar
+        DATA(ev_trim) = lcl_scanner=>trim( entry_val ).
+        DATA child_node TYPE ty_node_ref.
+        IF strlen( ev_trim ) > 0 AND
+           ( substring( val = ev_trim off = 0 len = 1 ) = `{` OR
+             substring( val = ev_trim off = 0 len = 1 ) = `[` ).
+          child_node = parse_flow( ev_trim ).
+        ELSE.
+          DATA ev TYPE string.
+          DATA en TYPE abap_bool.
+          resolve_scalar( EXPORTING raw = ev_trim IMPORTING value = ev is_null = en ).
+          child_node = lcl_tree=>new_scalar( value = ev is_null = en ).
+        ENDIF.
+        lcl_tree=>add_child( node = node key = lcl_scanner=>trim( entry_key ) child = child_node ).
       ELSE.
-        " sequence item
+        " sequence item: nested collection or scalar
         DATA(fc1) = substring( val = trimmed off = 0 len = 1 ).
         IF fc1 = `{` OR fc1 = `[`.
           lcl_tree=>add_child( node = node child = parse_flow( trimmed ) ).

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -1152,6 +1152,8 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
         DATA lv_sfxl   TYPE i.
         DATA lv_basl   TYPE i.
         DATA lv_triml  TYPE i.
+        " fingerprint = sorted component names + their RTTI absolute names for cache key
+        DATA lv_fingerprint TYPE string.
         LOOP AT node->children INTO DATA(child).
           DATA(base_name) = sanitize_name( child-key ).
           lv_final = base_name.
@@ -1173,13 +1175,26 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
                                             type = CAST cl_abap_datadescr( child_td ) )
                  TO lt_comps.
           APPEND child_ref TO lt_refs.
+          " accumulate fingerprint: compname:absolute_name|
+          lv_fingerprint = lv_fingerprint && lv_final && `:` && child_td->absolute_name && `|`.
         ENDLOOP.
         IF lt_comps IS INITIAL.
           " empty mapping → string fallback (empty struct not creatable)
           CREATE DATA rr_data TYPE string.
           RETURN.
         ENDIF.
-        DATA(struct_td) = cl_abap_structdescr=>create( lt_comps ).
+        " Look up or create the struct type descriptor (expensive cl_abap_structdescr=>create avoided
+        " on cache hit — pays off at 100k+ rows of same struct shape)
+        DATA struct_td TYPE REF TO cl_abap_structdescr.
+        READ TABLE mt_struct_td_cache WITH TABLE KEY fingerprint = lv_fingerprint
+          INTO DATA(lv_cache_hit).
+        IF sy-subrc = 0.
+          struct_td = lv_cache_hit-struct_td.
+        ELSE.
+          struct_td = cl_abap_structdescr=>create( lt_comps ).
+          INSERT VALUE ty_struct_td_entry( fingerprint = lv_fingerprint struct_td = struct_td )
+            INTO TABLE mt_struct_td_cache.
+        ENDIF.
         CREATE DATA rr_data TYPE HANDLE struct_td.
         " fill each component using deduped names (index-parallel to lt_refs)
         ASSIGN rr_data->* TO FIELD-SYMBOL(<struct>).

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -367,24 +367,29 @@ CLASS lcl_parser IMPLEMENTATION.
 
   METHOD parse.
     CLEAR mt_anchors.
-    " Build first-doc view: a leading doc_start (---) with no prior content is skipped
-    " (preamble marker); a doc_start encountered AFTER content ends the first doc.
-    " doc_marker (...) also ends the first doc.
-    " This preserves backward-compat: single-doc parse sees exactly the first document.
+    DATA(idx) = 1.
+    " Fast path: no document boundaries → parse lines directly, no copy.
+    LOOP AT lines TRANSPORTING NO FIELDS WHERE doc_start = abap_true OR doc_marker = abap_true.
+      EXIT.
+    ENDLOOP.
+    IF sy-subrc <> 0.
+      IF lines IS INITIAL.
+        root = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
+        RETURN.
+      ENDIF.
+      root = parse_block( EXPORTING lines = lines CHANGING idx = idx ).
+      RETURN.
+    ENDIF.
+    " Boundary present: build first-doc view (preamble --- skipped; --- or ... after content ends doc 1).
     DATA first_doc TYPE ty_lines.
     LOOP AT lines INTO DATA(scan_ln).
       IF scan_ln-doc_start = abap_true.
-        IF first_doc IS NOT INITIAL.
-          EXIT.  " content already collected — this --- starts doc 2
-        ENDIF.
-        CONTINUE.  " leading --- with no prior content: preamble, skip
+        IF first_doc IS NOT INITIAL. EXIT. ENDIF.
+        CONTINUE.
       ENDIF.
-      IF scan_ln-doc_marker = abap_true.
-        EXIT.  " ... ends first doc
-      ENDIF.
+      IF scan_ln-doc_marker = abap_true. EXIT. ENDIF.
       APPEND scan_ln TO first_doc.
     ENDLOOP.
-    DATA(idx) = 1.
     IF first_doc IS INITIAL.
       root = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
       RETURN.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -29,7 +29,7 @@ CLASS lcl_scanner IMPLEMENTATION.
         ENDCASE.
       ENDWHILE.
       DATA(indent) = off.
-      DATA(body)   = CONV string( r+off ).
+      DATA(body)   = r+off.
       body = strip_comment( body ).
       body = trim_right( body ).
       CHECK body IS NOT INITIAL AND body <> `---`.
@@ -44,6 +44,7 @@ CLASS lcl_scanner IMPLEMENTATION.
   METHOD strip_comment.
     " '#' at pos 0 or preceded by whitespace -- strip from there
     " Quoted-# awareness deferred to Task 5
+    ##REGEX_POSIX
     FIND FIRST OCCURRENCE OF REGEX `(^|\s)#` IN body MATCH OFFSET DATA(mo).
     IF sy-subrc = 0.
       result = body(mo).

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -472,8 +472,12 @@ CLASS lcl_parser IMPLEMENTATION.
     IF has_inline = abap_true.
       " trim leading/trailing only — preserve internal spaces in quoted scalars
       DATA(trimmed) = lcl_scanner=>trim( inline_value ).
-      " alias?
-      IF strlen( trimmed ) > 0 AND substring( val = trimmed off = 0 len = 1 ) = `*`.
+      " alias? require *<valid-name> — whole token, name chars only (A-Za-z0-9_-)
+      DATA(alias_rest) = COND string( WHEN strlen( trimmed ) > 1
+                                      THEN substring( val = trimmed off = 1 ) ELSE `` ).
+      IF strlen( trimmed ) > 1
+         AND substring( val = trimmed off = 0 len = 1 ) = `*`
+         AND alias_rest CO `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-`.
         node = resolve_alias( raw = trimmed lineno = 0 ).
         RETURN.
       ENDIF.
@@ -721,8 +725,8 @@ CLASS lcl_parser IMPLEMENTATION.
 
   METHOD strip_anchor.
     " Detect and remove a leading &name prefix from raw.
+    " &name must be &[A-Za-z0-9_-]+ — bare & or &.foo is not an anchor.
     " Returns anchor name if found, empty string otherwise.
-    " raw is CHANGING — the anchor prefix is stripped in-place.
     DATA(len) = strlen( raw ).
     IF len < 2 OR substring( val = raw off = 0 len = 1 ) <> `&`.
       RETURN.
@@ -731,7 +735,13 @@ CLASS lcl_parser IMPLEMENTATION.
     WHILE i < len AND substring( val = raw off = i len = 1 ) <> ` `.
       i = i + 1.
     ENDWHILE.
-    aname = substring( val = raw off = 1 len = i - 1 ).
+    DATA(candidate) = substring( val = raw off = 1 len = i - 1 ).
+    IF candidate IS INITIAL
+       OR NOT ( candidate CO
+         `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-` ).
+      RETURN.
+    ENDIF.
+    aname = candidate.
     raw   = lcl_scanner=>trim( substring( val = raw off = i ) ).
   ENDMETHOD.
 

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -1233,11 +1233,12 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
         APPEND first_ref TO lt_child_refs.
         DATA lv_uniform TYPE abap_bool VALUE abap_true.
         DATA li TYPE i VALUE 2.
-        WHILE li <= child_count AND lv_uniform = abap_true.
+        WHILE li <= child_count.
           DATA(chk_ref) = generate( node->children[ li ]-node ).
           APPEND chk_ref TO lt_child_refs.
           DATA(chk_td)  = cl_abap_typedescr=>describe_by_data_ref( chk_ref ).
-          IF chk_td->kind <> first_td->kind.
+          IF chk_td->kind <> first_td->kind
+             OR chk_td->absolute_name <> first_td->absolute_name.
             lv_uniform = abap_false.
           ENDIF.
           li = li + 1.
@@ -1252,10 +1253,20 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
         CREATE DATA rr_data TYPE HANDLE tab_td.
         ASSIGN rr_data->* TO FIELD-SYMBOL(<table>).
         " fill from collected refs — no regeneration needed
-        LOOP AT lt_child_refs INTO DATA(row_ref).
-          ASSIGN row_ref->* TO FIELD-SYMBOL(<row>).
-          INSERT <row> INTO TABLE <table>.
-        ENDLOOP.
+        IF lv_uniform = abap_true.
+          LOOP AT lt_child_refs INTO DATA(row_ref).
+            ASSIGN row_ref->* TO FIELD-SYMBOL(<row>).
+            INSERT <row> INTO TABLE <table>.
+          ENDLOOP.
+        ELSE.
+          " non-uniform fallback is string table — convert each value via string
+          DATA lv_sval TYPE string.
+          LOOP AT lt_child_refs INTO DATA(row_ref2).
+            ASSIGN row_ref2->* TO FIELD-SYMBOL(<rval>).
+            lv_sval = <rval>.
+            INSERT lv_sval INTO TABLE <table>.
+          ENDLOOP.
+        ENDIF.
 
     ENDCASE.
   ENDMETHOD.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -1082,4 +1082,366 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
 ENDCLASS.
 
 CLASS lcl_emitter IMPLEMENTATION.
+
+  METHOD emit.
+    " prepend header_comment lines (before doc marker)
+    IF header_comment IS NOT INITIAL.
+      DATA lines_str TYPE string_table.
+      SPLIT header_comment AT cl_abap_char_utilities=>newline INTO TABLE lines_str.
+      LOOP AT lines_str INTO DATA(hl).
+        r_yaml = r_yaml && `# ` && hl && cl_abap_char_utilities=>newline.
+      ENDLOOP.
+    ENDIF.
+    IF emit_doc_markers = abap_true.
+      r_yaml = r_yaml && `---` && cl_abap_char_utilities=>newline.
+    ENDIF.
+    DATA(body) = emit_node( data           = data
+                            compress       = compress
+                            pretty_name    = pretty_name
+                            name_mappings  = name_mappings
+                            indent_step    = indent_step
+                            quote_style    = quote_style ).
+    IF name IS NOT INITIAL.
+      " wrap body under name key — indent each line of body
+      r_yaml = r_yaml && name && `:` && cl_abap_char_utilities=>newline
+                      && indent_block( text = body n = indent_step ).
+    ELSE.
+      r_yaml = r_yaml && body.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD emit_node.
+    DATA(td) = cl_abap_typedescr=>describe_by_data( data ).
+
+    CASE td->kind.
+
+      WHEN cl_abap_typedescr=>kind_struct.
+        DATA(sd) = CAST cl_abap_structdescr( td ).
+        DATA lv_first TYPE abap_bool VALUE abap_true.
+        LOOP AT sd->components INTO DATA(comp).
+          " get component value via field-symbol
+          ASSIGN COMPONENT comp-name OF STRUCTURE data TO FIELD-SYMBOL(<v>).
+          CHECK sy-subrc = 0.
+          " compress: skip initial values
+          IF compress = abap_true.
+            DATA(comp_td) = cl_abap_typedescr=>describe_by_data( <v> ).
+            IF comp_td->kind = cl_abap_typedescr=>kind_elem.
+              ASSIGN <v> TO FIELD-SYMBOL(<ev>).
+              " compare to initial — create a same-typed initial ref
+              DATA lv_init_ref TYPE REF TO data.
+              DATA(comp_datadescr) = CAST cl_abap_datadescr( comp_td ).
+              CREATE DATA lv_init_ref TYPE HANDLE comp_datadescr.
+              ASSIGN lv_init_ref->* TO FIELD-SYMBOL(<iv>).
+              IF <ev> = <iv>. CONTINUE. ENDIF.
+            ENDIF.
+          ENDIF.
+          DATA(key)   = format_key( comp_name = comp-name pretty_name = pretty_name name_mappings = name_mappings ).
+          DATA(val_s) = emit_node( data = <v> compress = compress pretty_name = pretty_name
+                                   name_mappings = name_mappings indent_step = indent_step
+                                   quote_style = quote_style ).
+          IF lv_first = abap_false.
+            result = result && cl_abap_char_utilities=>newline.
+          ENDIF.
+          lv_first = abap_false.
+          " check if val_s is a multi-line block (contains newline)
+          IF val_s CA cl_abap_char_utilities=>newline.
+            result = result && key && `:` && cl_abap_char_utilities=>newline
+                            && indent_block( text = val_s n = indent_step ).
+          ELSE.
+            result = result && key && `: ` && val_s.
+          ENDIF.
+        ENDLOOP.
+
+      WHEN cl_abap_typedescr=>kind_table.
+        DATA(tabd) = CAST cl_abap_tabledescr( td ).
+        DATA(line_td) = tabd->get_table_line_type( ).
+        DATA lv_tfirst TYPE abap_bool VALUE abap_true.
+        DATA nl_pos TYPE i.
+        ASSIGN data TO FIELD-SYMBOL(<tab>).
+        LOOP AT <tab> ASSIGNING FIELD-SYMBOL(<row>).
+          DATA(row_s) = emit_node( data = <row> compress = compress pretty_name = pretty_name
+                                   name_mappings = name_mappings indent_step = indent_step
+                                   quote_style = quote_style ).
+          IF lv_tfirst = abap_false.
+            result = result && cl_abap_char_utilities=>newline.
+          ENDIF.
+          lv_tfirst = abap_false.
+          IF row_s CA cl_abap_char_utilities=>newline.
+            " multi-line mapping row: first field inline after dash, rest indented
+            FIND FIRST OCCURRENCE OF cl_abap_char_utilities=>newline IN row_s MATCH OFFSET nl_pos.
+            DATA(first_line) = substring( val = row_s len = nl_pos ).
+            DATA(rest_lines) = substring( val = row_s off = nl_pos + 1 ).
+            result = result && `- ` && first_line && cl_abap_char_utilities=>newline
+                            && indent_block( text = rest_lines n = 2 ).
+          ELSE.
+            result = result && `- ` && row_s.
+          ENDIF.
+        ENDLOOP.
+
+      WHEN cl_abap_typedescr=>kind_elem.
+        DATA(eld) = CAST cl_abap_elemdescr( td ).
+        ASSIGN data TO FIELD-SYMBOL(<elem>).
+        DATA lv_raw TYPE string.
+        " type-specific serialization
+        CASE eld->type_kind.
+          WHEN cl_abap_typedescr=>typekind_date.
+            " d → YYYY-MM-DD
+            DATA lv_d TYPE string.
+            lv_d = <elem>.
+            IF strlen( lv_d ) = 8 AND lv_d <> `00000000`.
+              result = substring( val = lv_d len = 4 ) && `-`
+                    && substring( val = lv_d off = 4 len = 2 ) && `-`
+                    && substring( val = lv_d off = 6 len = 2 ).
+            ELSE.
+              result = quote_scalar( value = lv_d quote_style = quote_style ).
+            ENDIF.
+          WHEN cl_abap_typedescr=>typekind_bool.
+            result = COND string( WHEN <elem> = abap_true THEN `true` ELSE `false` ).
+          WHEN cl_abap_typedescr=>typekind_char.
+            " abap_bool (c len 1) is already handled above; other c-type: treat as string
+            lv_raw = <elem>.
+            result = quote_scalar( value = lv_raw quote_style = quote_style ).
+          WHEN cl_abap_typedescr=>typekind_string.
+            lv_raw = <elem>.
+            result = quote_scalar( value = lv_raw quote_style = quote_style ).
+          WHEN OTHERS.
+            " numeric types: integer, packed, float, decfloat — emit unquoted
+            lv_raw = <elem>.
+            " strip trailing spaces that ABAP adds to numeric string conversion
+            WHILE strlen( lv_raw ) > 0
+              AND substring( val = lv_raw off = strlen( lv_raw ) - 1 len = 1 ) = ` `.
+              lv_raw = substring( val = lv_raw len = strlen( lv_raw ) - 1 ).
+            ENDWHILE.
+            result = lv_raw.
+        ENDCASE.
+
+      WHEN OTHERS.
+        result = `~`.
+
+    ENDCASE.
+  ENDMETHOD.
+
+  METHOD format_key.
+    " check name_mappings first
+    READ TABLE name_mappings WITH TABLE KEY abap = comp_name INTO DATA(nm).
+    IF sy-subrc = 0.
+      result = nm-yaml.
+      RETURN.
+    ENDIF.
+    " apply pretty_name transform
+    DATA(raw) = to_lower( comp_name ).
+    CASE pretty_name.
+      WHEN z_ui2_yaml=>pretty_mode-none.
+        result = comp_name.
+      WHEN z_ui2_yaml=>pretty_mode-low_case.
+        result = raw.
+      WHEN z_ui2_yaml=>pretty_mode-camel_case.
+        " MY_FIELD → myField
+        DATA lv_out TYPE string.
+        DATA lv_cap TYPE abap_bool VALUE abap_false.
+        DATA i TYPE i.
+        DATA(len) = strlen( raw ).
+        WHILE i < len.
+          DATA(c) = substring( val = raw off = i len = 1 ).
+          IF c = `_`.
+            lv_cap = abap_true.
+          ELSE.
+            IF lv_cap = abap_true.
+              lv_out = lv_out && to_upper( c ).
+              lv_cap = abap_false.
+            ELSE.
+              lv_out = lv_out && c.
+            ENDIF.
+          ENDIF.
+          i = i + 1.
+        ENDWHILE.
+        result = lv_out.
+      WHEN z_ui2_yaml=>pretty_mode-pascal_case.
+        DATA lv_out2 TYPE string.
+        DATA lv_cap2 TYPE abap_bool VALUE abap_true.
+        DATA j TYPE i.
+        DATA(len2) = strlen( raw ).
+        WHILE j < len2.
+          DATA(c2) = substring( val = raw off = j len = 1 ).
+          IF c2 = `_`.
+            lv_cap2 = abap_true.
+          ELSE.
+            IF lv_cap2 = abap_true.
+              lv_out2 = lv_out2 && to_upper( c2 ).
+              lv_cap2 = abap_false.
+            ELSE.
+              lv_out2 = lv_out2 && c2.
+            ENDIF.
+          ENDIF.
+          j = j + 1.
+        ENDWHILE.
+        result = lv_out2.
+      WHEN OTHERS.
+        result = comp_name.
+    ENDCASE.
+  ENDMETHOD.
+
+  METHOD looks_like_number.
+    DATA(len) = strlen( value ).
+    IF len = 0. RETURN. ENDIF.
+    DATA off TYPE i.
+    IF substring( val = value off = 0 len = 1 ) = `-`. off = 1. ENDIF.
+    DATA(rem) = len - off.
+    IF rem = 0. RETURN. ENDIF.
+    " integer: all digits (1-9 digits: avoid huge numbers causing issues for round-trip)
+    DATA(digits_only) = substring( val = value off = off ).
+    IF digits_only CO `0123456789`.
+      result = abap_true.
+      RETURN.
+    ENDIF.
+    " decimal: digits dot digits
+    DATA dot_seen TYPE abap_bool VALUE abap_false.
+    DATA di TYPE i VALUE 0.
+    WHILE di < strlen( digits_only ).
+      DATA(dc) = substring( val = digits_only off = di len = 1 ).
+      IF dc = `.`.
+        IF dot_seen = abap_true. RETURN. ENDIF.
+        dot_seen = abap_true.
+      ELSEIF NOT ( dc CO `0123456789` ).
+        RETURN.
+      ENDIF.
+      di = di + 1.
+    ENDWHILE.
+    IF dot_seen = abap_true AND di > 1.
+      result = abap_true.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD quote_scalar.
+    " Decide whether quoting is needed; if so, always double-quote.
+    DATA lv_need TYPE abap_bool.
+    DATA(len) = strlen( value ).
+
+    " always-double mode
+    IF quote_style = 'D'.
+      result = `"` && escape_dq( value ) && `"`.
+      RETURN.
+    ENDIF.
+
+    " empty string must be quoted
+    IF len = 0.
+      result = `""`.
+      RETURN.
+    ENDIF.
+
+    DATA(first) = substring( val = value off = 0 len = 1 ).
+
+    " starts with a YAML indicator or space
+    IF first CA `- ? : , [ ] { } # & * ! | > ' " % @ ` && '`'.
+      lv_need = abap_true.
+    ENDIF.
+
+    " ends with ':'
+    IF lv_need = abap_false AND substring( val = value off = len - 1 len = 1 ) = `:`.
+      lv_need = abap_true.
+    ENDIF.
+
+    " contains ': ' or ' #'
+    IF lv_need = abap_false.
+      IF value CS `: ` OR value CS ` #`.
+        lv_need = abap_true.
+      ENDIF.
+    ENDIF.
+
+    " leading or trailing whitespace
+    IF lv_need = abap_false.
+      IF first = ` ` OR substring( val = value off = len - 1 len = 1 ) = ` `.
+        lv_need = abap_true.
+      ENDIF.
+    ENDIF.
+
+    " looks like a non-string YAML type: bool, null, number
+    IF lv_need = abap_false.
+      IF value = `true` OR value = `false` OR value = `null` OR value = `~`.
+        lv_need = abap_true.
+      ENDIF.
+    ENDIF.
+
+    IF lv_need = abap_false.
+      IF looks_like_number( value ) = abap_true.
+        lv_need = abap_true.
+      ENDIF.
+    ENDIF.
+
+    " date-like: YYYY-MM-DD
+    IF lv_need = abap_false AND len = 10.
+      IF substring( val = value off = 4 len = 1 ) = `-`
+         AND substring( val = value off = 7 len = 1 ) = `-`
+         AND substring( val = value off = 0 len = 4 ) CO `0123456789`
+         AND substring( val = value off = 5 len = 2 ) CO `0123456789`
+         AND substring( val = value off = 8 len = 2 ) CO `0123456789`.
+        lv_need = abap_true.
+      ENDIF.
+    ENDIF.
+
+    IF lv_need = abap_true.
+      result = `"` && escape_dq( value ) && `"`.
+    ELSE.
+      result = value.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD escape_dq.
+    DATA i TYPE i.
+    DATA(len) = strlen( value ).
+    WHILE i < len.
+      DATA(c) = substring( val = value off = i len = 1 ).
+      CASE c.
+        WHEN `"`.  result = result && `\"`.
+        WHEN `\`.  result = result && `\\`.
+        WHEN cl_abap_char_utilities=>newline.       result = result && `\n`.
+        WHEN cl_abap_char_utilities=>horizontal_tab. result = result && `\t`.
+        WHEN OTHERS. result = result && c.
+      ENDCASE.
+      i = i + 1.
+    ENDWHILE.
+  ENDMETHOD.
+
+  METHOD indent_block.
+    " Prepend n spaces to every non-empty line of text.
+    " text may or may not end with newline.
+    DATA pad TYPE string.
+    DATA k TYPE i.
+    WHILE k < n.
+      pad = pad && ` `.
+      k = k + 1.
+    ENDWHILE.
+    DATA lines_t TYPE string_table.
+    SPLIT text AT cl_abap_char_utilities=>newline INTO TABLE lines_t.
+    DATA lv_last TYPE i VALUE 0.
+    " detect trailing newline: if text ends with NL, last token is empty
+    DATA(tlen) = strlen( text ).
+    DATA lv_has_trail TYPE abap_bool.
+    IF tlen > 0 AND substring( val = text off = tlen - 1 len = 1 ) = cl_abap_char_utilities=>newline.
+      lv_has_trail = abap_true.
+    ENDIF.
+    DATA(total) = lines( lines_t ).
+    DATA idx TYPE i VALUE 1.
+    WHILE idx <= total.
+      DATA(ln) = lines_t[ idx ].
+      " skip the trailing empty entry produced by trailing NL
+      IF idx = total AND lv_has_trail = abap_true AND ln IS INITIAL.
+        EXIT.
+      ENDIF.
+      IF result IS NOT INITIAL.
+        result = result && cl_abap_char_utilities=>newline.
+      ENDIF.
+      IF ln IS NOT INITIAL.
+        result = result && pad && ln.
+      ELSE.
+        result = result && ln.
+      ENDIF.
+      idx = idx + 1.
+    ENDWHILE.
+    " restore trailing newline
+    IF lv_has_trail = abap_true.
+      result = result && cl_abap_char_utilities=>newline.
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -829,6 +829,21 @@ CLASS lcl_typed_mapper IMPLEMENTATION.
         IF node->node-is_null = abap_true.
           RETURN.  " leave initial
         ENDIF.
+        " bool target: map true/false/x → abap_true/abap_false
+        DATA(eld2) = CAST cl_abap_elemdescr( td ).
+        IF eld2->absolute_name CP `*ABAP_BOOL*` OR eld2->absolute_name CP `*BOOLEAN*`
+           OR eld2->absolute_name CP `*BOOLE_D*`  OR eld2->absolute_name CP `*XFELD*`
+           OR eld2->absolute_name CP `*XSDBOOLEAN*`.
+          DATA(lv_lower) = to_lower( node->node-value ).
+          IF lv_lower = `true` OR lv_lower = `x`.
+            data = abap_true.
+          ELSEIF lv_lower = `false` OR lv_lower = ``.
+            data = abap_false.
+          ELSEIF strict = abap_true.
+            RAISE EXCEPTION TYPE cx_sy_move_cast_error.
+          ENDIF.
+          RETURN.
+        ENDIF.
         TRY.
             data = node->node-value.
           CATCH cx_sy_conversion_error cx_sy_move_cast_error INTO DATA(lx).

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -759,6 +759,91 @@ CLASS lcl_parser IMPLEMENTATION.
 ENDCLASS.
 
 CLASS lcl_typed_mapper IMPLEMENTATION.
+
+  METHOD map.
+    " Describe the target data
+    DATA(td) = cl_abap_typedescr=>describe_by_data( data ).
+
+    CASE td->kind.
+
+      WHEN cl_abap_typedescr=>kind_struct.
+        " mapping node → structure: match children by component name
+        IF node->node-kind <> c_node=>mapping.
+          RETURN.  " wrong node kind — leave data initial
+        ENDIF.
+        DATA(sd) = CAST cl_abap_structdescr( td ).
+        LOOP AT node->children INTO DATA(child).
+          " find matching component: check name_mappings first, then case-insensitive
+          DATA lv_compname TYPE abap_compname.
+          CLEAR lv_compname.
+          " check name_mappings (yaml key → abap name)
+          LOOP AT name_mappings INTO DATA(nm).
+            IF nm-yaml = child-key.
+              lv_compname = nm-abap.
+              EXIT.
+            ENDIF.
+          ENDLOOP.
+          IF lv_compname IS INITIAL.
+            " case-insensitive match: yaml key uppercased vs component name
+            DATA(upper_key) = to_upper( child-key ).
+            LOOP AT sd->components INTO DATA(comp).
+              IF comp-name = upper_key.
+                lv_compname = comp-name.
+                EXIT.
+              ENDIF.
+            ENDLOOP.
+          ENDIF.
+          CHECK lv_compname IS NOT INITIAL.
+          " assign component via field-symbol
+          ASSIGN COMPONENT lv_compname OF STRUCTURE data TO FIELD-SYMBOL(<comp_data>).
+          CHECK sy-subrc = 0.
+          map( EXPORTING node          = child-node
+                         pretty_name   = pretty_name
+                         name_mappings = name_mappings
+                         strict        = strict
+               CHANGING  data          = <comp_data> ).
+        ENDLOOP.
+
+      WHEN cl_abap_typedescr=>kind_table.
+        " sequence node → internal table
+        IF node->node-kind <> c_node=>sequence.
+          RETURN.
+        ENDIF.
+        DATA(tabd) = CAST cl_abap_tabledescr( td ).
+        DATA(line_td) = tabd->get_table_line_type( ).
+        LOOP AT node->children INTO DATA(seq_child).
+          " create a line instance via RTTI and recurse
+          DATA lv_line_ref TYPE REF TO data.
+          CREATE DATA lv_line_ref TYPE HANDLE line_td.
+          ASSIGN lv_line_ref->* TO FIELD-SYMBOL(<line>).
+          map( EXPORTING node          = seq_child-node
+                         pretty_name   = pretty_name
+                         name_mappings = name_mappings
+                         strict        = strict
+               CHANGING  data          = <line> ).
+          INSERT <line> INTO TABLE data.
+        ENDLOOP.
+
+      WHEN cl_abap_typedescr=>kind_elem.
+        " scalar → elementary
+        IF node->node-is_null = abap_true.
+          RETURN.  " leave initial
+        ENDIF.
+        TRY.
+            data = node->node-value.
+          CATCH cx_sy_conversion_error cx_sy_move_cast_error INTO DATA(lx).
+            IF strict = abap_true.
+              " bridge: wrap in cx_sy_move_cast_error
+              RAISE EXCEPTION TYPE cx_sy_move_cast_error.
+            ENDIF.
+            " lenient: leave data initial (already initial before failed MOVE)
+        ENDTRY.
+
+      WHEN OTHERS.
+        " reference, object, etc. — skip
+    ENDCASE.
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS lcl_gen_mapper IMPLEMENTATION.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -314,6 +314,7 @@ ENDCLASS.
 CLASS lcl_parser IMPLEMENTATION.
 
   METHOD parse.
+    CLEAR mt_anchors.
     DATA(idx) = 1.
     IF lines IS INITIAL.
       root = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
@@ -471,18 +472,37 @@ CLASS lcl_parser IMPLEMENTATION.
     IF has_inline = abap_true.
       " trim leading/trailing only — preserve internal spaces in quoted scalars
       DATA(trimmed) = lcl_scanner=>trim( inline_value ).
-      IF strlen( trimmed ) > 0 AND
-         ( substring( val = trimmed off = 0 len = 1 ) = `{` OR
-           substring( val = trimmed off = 0 len = 1 ) = `[` ).
-        node = parse_flow( trimmed ).
-      ELSE.
-        DATA lv_val  TYPE string.
-        DATA lv_null TYPE abap_bool.
-        resolve_scalar( EXPORTING raw = trimmed IMPORTING value = lv_val is_null = lv_null ).
-        node = lcl_tree=>new_scalar( value = lv_val is_null = lv_null ).
+      " alias?
+      IF strlen( trimmed ) > 0 AND substring( val = trimmed off = 0 len = 1 ) = `*`.
+        node = resolve_alias( raw = trimmed lineno = 0 ).
+        RETURN.
       ENDIF.
-    ELSEIF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
+      " strip anchor prefix — trimmed may become empty if anchor was the only inline content
+      DATA(aname) = strip_anchor( CHANGING raw = trimmed ).
+      IF trimmed IS NOT INITIAL.
+        " inline value exists after optional anchor
+        IF strlen( trimmed ) > 0 AND
+           ( substring( val = trimmed off = 0 len = 1 ) = `{` OR
+             substring( val = trimmed off = 0 len = 1 ) = `[` ).
+          node = parse_flow( trimmed ).
+        ELSE.
+          DATA lv_val  TYPE string.
+          DATA lv_null TYPE abap_bool.
+          resolve_scalar( EXPORTING raw = trimmed IMPORTING value = lv_val is_null = lv_null ).
+          node = lcl_tree=>new_scalar( value = lv_val is_null = lv_null ).
+        ENDIF.
+        IF aname IS NOT INITIAL.
+          INSERT VALUE ty_anchor_entry( name = aname node = node ) INTO TABLE mt_anchors.
+        ENDIF.
+        RETURN.
+      ENDIF.
+      " anchor was entire inline content — fall through to block/null with anchor registration
+    ENDIF.
+    IF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
       node = parse_block( EXPORTING lines = lines CHANGING idx = idx ).
+      IF aname IS NOT INITIAL.
+        INSERT VALUE ty_anchor_entry( name = aname node = node ) INTO TABLE mt_anchors.
+      ENDIF.
     ELSE.
       node = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
     ENDIF.
@@ -697,6 +717,33 @@ CLASS lcl_parser IMPLEMENTATION.
         ENDIF.
       ENDIF.
     ENDLOOP.
+  ENDMETHOD.
+
+  METHOD strip_anchor.
+    " Detect and remove a leading &name prefix from raw.
+    " Returns anchor name if found, empty string otherwise.
+    " raw is CHANGING — the anchor prefix is stripped in-place.
+    DATA(len) = strlen( raw ).
+    IF len < 2 OR substring( val = raw off = 0 len = 1 ) <> `&`.
+      RETURN.
+    ENDIF.
+    DATA(i) = 1.
+    WHILE i < len AND substring( val = raw off = i len = 1 ) <> ` `.
+      i = i + 1.
+    ENDWHILE.
+    aname = substring( val = raw off = 1 len = i - 1 ).
+    raw   = lcl_scanner=>trim( substring( val = raw off = i ) ).
+  ENDMETHOD.
+
+  METHOD resolve_alias.
+    " raw must be exactly *name (already trimmed)
+    DATA(name) = substring( val = raw off = 1 ).
+    READ TABLE mt_anchors WITH TABLE KEY name = name INTO DATA(entry).
+    IF sy-subrc <> 0.
+      RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+        EXPORTING value = |Undefined alias '{ raw }' at line { lineno }|.
+    ENDIF.
+    node = entry-node.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -975,38 +975,58 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
 
       WHEN c_node=>mapping.
         " Build a dynamic structure: one component per child, typed from recursive generate()
-        DATA lt_comps   TYPE cl_abap_structdescr=>component_table.
-        DATA lt_refs    TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY.
+        DATA lt_comps  TYPE cl_abap_structdescr=>component_table.
+        DATA lt_refs   TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY.
+        " lt_names: deduped final component names, index-parallel to lt_comps/lt_refs
+        DATA lt_names  TYPE STANDARD TABLE OF abap_compname WITH DEFAULT KEY.
+        DATA lt_used   TYPE SORTED TABLE OF abap_compname WITH UNIQUE KEY table_line.
+        DATA lv_final  TYPE abap_compname.
+        DATA lv_sfx    TYPE i.
+        DATA lv_sfxs   TYPE string.
+        DATA lv_sfxl   TYPE i.
+        DATA lv_basl   TYPE i.
+        DATA lv_triml  TYPE i.
         LOOP AT node->children INTO DATA(child).
-          DATA(comp_name) = sanitize_name( child-key ).
-          " recursively generate child value to get its type
+          DATA(base_name) = sanitize_name( child-key ).
+          lv_final = base_name.
+          lv_sfx   = 1.
+          " ponytail: O(n) collision scan per key, fine for typical config mappings
+          WHILE line_exists( lt_used[ table_line = lv_final ] ).
+            lv_sfx  = lv_sfx + 1.
+            lv_sfxs = |_{ lv_sfx }|.
+            lv_sfxl = strlen( lv_sfxs ).
+            lv_basl = strlen( base_name ).
+            lv_triml = COND i( WHEN lv_basl + lv_sfxl > 30 THEN 30 - lv_sfxl ELSE lv_basl ).
+            lv_final = substring( val = base_name len = lv_triml ) && lv_sfxs.
+          ENDWHILE.
+          INSERT lv_final INTO TABLE lt_used.
+          APPEND lv_final TO lt_names.
           DATA(child_ref) = generate( child-node ).
           DATA(child_td)  = cl_abap_typedescr=>describe_by_data_ref( child_ref ).
-          APPEND VALUE abap_componentdescr( name = comp_name
+          APPEND VALUE abap_componentdescr( name = lv_final
                                             type = CAST cl_abap_datadescr( child_td ) )
                  TO lt_comps.
           APPEND child_ref TO lt_refs.
         ENDLOOP.
         IF lt_comps IS INITIAL.
-          " empty mapping → empty structure
+          " empty mapping → string fallback (empty struct not creatable)
           CREATE DATA rr_data TYPE string.
           RETURN.
         ENDIF.
         DATA(struct_td) = cl_abap_structdescr=>create( lt_comps ).
         CREATE DATA rr_data TYPE HANDLE struct_td.
-        " fill each component from the pre-generated child refs
+        " fill each component using deduped names (index-parallel to lt_refs)
         ASSIGN rr_data->* TO FIELD-SYMBOL(<struct>).
         DATA(ci) = 1.
-        LOOP AT node->children INTO DATA(fill_child).
-          DATA(fill_name) = sanitize_name( fill_child-key ).
-          ASSIGN COMPONENT fill_name OF STRUCTURE <struct> TO FIELD-SYMBOL(<comp>).
+        WHILE ci <= lines( lt_names ).
+          ASSIGN COMPONENT lt_names[ ci ] OF STRUCTURE <struct> TO FIELD-SYMBOL(<comp>).
           IF sy-subrc = 0.
             DATA(fill_ref) = lt_refs[ ci ].
             ASSIGN fill_ref->* TO FIELD-SYMBOL(<val>).
             <comp> = <val>.
           ENDIF.
           ci = ci + 1.
-        ENDLOOP.
+        ENDWHILE.
 
       WHEN c_node=>sequence.
         " Build typed table: detect element type from first child, fall back to string if mixed

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -81,6 +81,12 @@ CLASS lcl_scanner IMPLEMENTATION.
     DATA ki        TYPE i.
     DATA bv_len    TYPE i.
 
+    " Anchor detection on block-scalar header
+    DATA blk_colon_pos   TYPE i.
+    DATA blk_after_colon TYPE string.
+    DATA blk_an_end      TYPE i.
+    DATA blk_anchor_cand TYPE string.
+
     total = lines( raw ).
     n     = 1.
     WHILE n <= total.
@@ -139,6 +145,27 @@ CLASS lcl_scanner IMPLEMENTATION.
                                 THEN substring( val = body off = blen - ind_len - 1 len = 1 )
                                 ELSE `` ).
         blk_key0 = trim_right( substring( val = body len = blen - ind_len ) ).
+        " Strip anchor token if present: key: &name |  → key: (store name in blk_anchor)
+        CLEAR: blk_colon_pos, blk_after_colon, blk_an_end, blk_anchor_cand, line-blk_anchor.
+        FIND FIRST OCCURRENCE OF `: ` IN blk_key0 MATCH OFFSET blk_colon_pos.
+        IF sy-subrc = 0.
+          blk_after_colon = lcl_scanner=>trim( substring( val = blk_key0 off = blk_colon_pos + 2 ) ).
+          IF strlen( blk_after_colon ) > 1
+             AND substring( val = blk_after_colon off = 0 len = 1 ) = `&`.
+            blk_an_end = 1.
+            WHILE blk_an_end < strlen( blk_after_colon )
+              AND substring( val = blk_after_colon off = blk_an_end len = 1 ) <> ` `.
+              blk_an_end = blk_an_end + 1.
+            ENDWHILE.
+            blk_anchor_cand = substring( val = blk_after_colon off = 1 len = blk_an_end - 1 ).
+            IF blk_anchor_cand IS NOT INITIAL
+               AND blk_anchor_cand CO
+                 `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-`.
+              line-blk_anchor = blk_anchor_cand.
+              blk_key0 = substring( val = blk_key0 len = blk_colon_pos + 1 ).
+            ENDIF.
+          ENDIF.
+        ENDIF.
         bk_len   = strlen( blk_key0 ).
         " Only a mapping block header: blk_key0 must end with ':' (and indicator preceded by space)
         IF ( blen = ind_len OR pre_char = ` ` )
@@ -381,6 +408,9 @@ CLASS lcl_parser IMPLEMENTATION.
       idx = idx + 1.
       IF cur-blk_scalar_hd = abap_true.
         lv_child = lcl_tree=>new_scalar( value = cur-blk_value ).
+        IF cur-blk_anchor IS NOT INITIAL.
+          INSERT VALUE ty_anchor_entry( name = cur-blk_anchor node = lv_child ) INTO TABLE mt_anchors.
+        ENDIF.
       ELSEIF lv_has = abap_false
          AND idx <= lines( lines )
          AND lines[ idx ]-indent = own_indent

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -7,6 +7,20 @@ ENDCLASS.
 CLASS lcl_node_ref IMPLEMENTATION.
 ENDCLASS.
 
+CLASS lcl_tree IMPLEMENTATION.
+  METHOD new_scalar.
+    node = NEW lcl_node_ref( ).
+    node->node = VALUE ty_node( kind = c_node=>scalar value = value is_null = is_null ).
+  ENDMETHOD.
+  METHOD new_collection.
+    node = NEW lcl_node_ref( ).
+    node->node-kind = kind.
+  ENDMETHOD.
+  METHOD add_child.
+    APPEND VALUE ty_child( key = key node = child ) TO node->children.
+  ENDMETHOD.
+ENDCLASS.
+
 CLASS lcl_scanner IMPLEMENTATION.
 
   METHOD scan.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -280,15 +280,37 @@ CLASS lcl_scanner IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD strip_comment.
-    " '#' at pos 0 or preceded by whitespace -- strip from there
-    " Quoted-# awareness deferred to Task 5
-    ##REGEX_POSIX
-    FIND FIRST OCCURRENCE OF REGEX `(^|\s)#` IN body MATCH OFFSET DATA(mo).
-    IF sy-subrc = 0.
-      result = body(mo).
-    ELSE.
-      result = body.
-    ENDIF.
+    " '#' preceded by whitespace (or at pos 0) -- strip from there
+    " Quote-aware: skip '#' inside single or double quotes
+    DATA in_sq TYPE abap_bool.
+    DATA in_dq TYPE abap_bool.
+    DATA(len) = strlen( body ).
+    DATA i    TYPE i.
+    WHILE i < len.
+      DATA(ch) = substring( val = body off = i len = 1 ).
+      IF in_sq = abap_true.
+        IF ch = `'` AND i + 1 < len AND substring( val = body off = i + 1 len = 1 ) = `'`.
+          i = i + 2. CONTINUE.
+        ENDIF.
+        IF ch = `'`. in_sq = abap_false. ENDIF.
+      ELSEIF in_dq = abap_true.
+        IF ch = `\` AND i + 1 < len. i = i + 2. CONTINUE. ENDIF.
+        IF ch = `"`. in_dq = abap_false. ENDIF.
+      ELSE.
+        CASE ch.
+          WHEN `'`. in_sq = abap_true.
+          WHEN `"`. in_dq = abap_true.
+          WHEN `#`.
+            " strip if at pos 0 or preceded by whitespace
+            IF i = 0 OR substring( val = body off = i - 1 len = 1 ) = ` `.
+              result = body(i).
+              RETURN.
+            ENDIF.
+        ENDCASE.
+      ENDIF.
+      i = i + 1.
+    ENDWHILE.
+    result = body.
   ENDMETHOD.
 
   METHOD trim_right.
@@ -359,6 +381,12 @@ CLASS lcl_parser IMPLEMENTATION.
       idx = idx + 1.
       IF cur-blk_scalar_hd = abap_true.
         lv_child = lcl_tree=>new_scalar( value = cur-blk_value ).
+      ELSEIF lv_has = abap_false
+         AND idx <= lines( lines )
+         AND lines[ idx ]-indent = own_indent
+         AND ( lines[ idx ]-content CP `- *` OR lines[ idx ]-content = `-` ).
+        " flush-style block sequence: items at SAME indent as the key belong to it
+        lv_child = parse_sequence( EXPORTING lines = lines own_indent = own_indent CHANGING idx = idx ).
       ELSE.
         lv_child = value_or_block( EXPORTING lines = lines own_indent = own_indent
                                              has_inline = lv_has inline_value = lv_inline

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -49,6 +49,14 @@ CLASS lcl_scanner IMPLEMENTATION.
     raw[ sentinel_idx ] = COND string( WHEN slen0 > 0
                                        THEN substring( val = sentinel_val len = slen0 - 1 )
                                        ELSE `` ).
+    " normalize CRLF: strip a trailing CR from every raw line once so block-scalar
+    " bodies (read from raw[] directly by collect_block_body) are covered too
+    LOOP AT raw ASSIGNING FIELD-SYMBOL(<r>).
+      DATA(rl) = strlen( <r> ).
+      IF rl > 0 AND substring( val = <r> off = rl - 1 len = 1 ) = cl_abap_char_utilities=>cr_lf(1).
+        <r> = substring( val = <r> len = rl - 1 ).
+      ENDIF.
+    ENDLOOP.
     DATA total        TYPE i.
     DATA n            TYPE i.
     DATA lv_raw_line  TYPE string.
@@ -80,11 +88,6 @@ CLASS lcl_scanner IMPLEMENTATION.
     n     = 1.
     WHILE n <= total.
       lv_raw_line   = raw[ n ].
-      " strip trailing CR so CRLF input is handled identically to LF
-      DATA(rr_len) = strlen( lv_raw_line ).
-      IF rr_len > 0 AND substring( val = lv_raw_line off = rr_len - 1 len = 1 ) = cl_abap_char_utilities=>cr_lf(1).
-        lv_raw_line = substring( val = lv_raw_line len = rr_len - 1 ).
-      ENDIF.
       rlen = strlen( lv_raw_line ).
       off  = 0.
       " count leading spaces; reject tab in leading whitespace

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -8,6 +8,58 @@ CLASS lcl_node_ref IMPLEMENTATION.
 ENDCLASS.
 
 CLASS lcl_scanner IMPLEMENTATION.
+
+  METHOD scan.
+    SPLIT text AT |\n| INTO TABLE DATA(raw).
+    LOOP AT raw INTO DATA(r).
+      DATA(n) = sy-tabix.
+      " count leading spaces; reject tab in leading whitespace
+      DATA(off) = 0.
+      WHILE off < strlen( r ).
+        CASE r+off(1).
+          WHEN ` `.
+            off = off + 1.
+          WHEN cl_abap_char_utilities=>horizontal_tab.
+            " ponytail: cx_sy_conversion_no_number is the nearest concrete subclass
+            " of cx_sy_conversion_error available on ER1; test catches the parent
+            RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+              EXPORTING value = |Tab in indentation at line { n }|.
+          WHEN OTHERS.
+            EXIT.
+        ENDCASE.
+      ENDWHILE.
+      DATA(indent) = off.
+      DATA(body)   = CONV string( r+off ).
+      body = strip_comment( body ).
+      body = trim_right( body ).
+      CHECK body IS NOT INITIAL AND body <> `---`.
+      DATA(line) = VALUE ty_line( lineno = n indent = indent content = body ).
+      IF body = `...`.
+        line-doc_marker = abap_true.
+      ENDIF.
+      APPEND line TO lines.
+    ENDLOOP.
+  ENDMETHOD.
+
+  METHOD strip_comment.
+    " '#' at pos 0 or preceded by whitespace -- strip from there
+    " Quoted-# awareness deferred to Task 5
+    FIND FIRST OCCURRENCE OF REGEX `(^|\s)#` IN body MATCH OFFSET DATA(mo).
+    IF sy-subrc = 0.
+      result = body(mo).
+    ELSE.
+      result = body.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD trim_right.
+    result = body.
+    WHILE strlen( result ) > 0
+      AND substring( val = result off = strlen( result ) - 1 len = 1 ) = ` `.
+      result = substring( val = result len = strlen( result ) - 1 ).
+    ENDWHILE.
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS lcl_parser IMPLEMENTATION.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -24,35 +24,259 @@ ENDCLASS.
 CLASS lcl_scanner IMPLEMENTATION.
 
   METHOD scan.
-    SPLIT text AT |\n| INTO TABLE DATA(raw).
-    LOOP AT raw INTO DATA(r).
-      DATA(n) = sy-tabix.
+    " Append sentinel so SPLIT preserves trailing empty lines
+    " (ABAP SPLIT drops trailing empty strings without it)
+    SPLIT text && `@` AT |\n| INTO TABLE DATA(raw).
+    DATA(sentinel_idx) = lines( raw ).
+    DATA(sentinel_val) = raw[ sentinel_idx ].
+    DATA(slen0)        = strlen( sentinel_val ).
+    raw[ sentinel_idx ] = COND string( WHEN slen0 > 0
+                                       THEN substring( val = sentinel_val len = slen0 - 1 )
+                                       ELSE `` ).
+    DATA total    TYPE i.
+    DATA n        TYPE i.
+    DATA rr       TYPE string.
+    DATA rlen     TYPE i.
+    DATA off      TYPE i.
+    DATA indent   TYPE i.
+    DATA body     TYPE string.
+    DATA blen     TYPE i.
+    DATA blk_ind  TYPE string.
+    DATA last2c   TYPE string.
+    DATA last1c   TYPE string.
+    DATA ind_len  TYPE i.
+    DATA pre_char TYPE string.
+    DATA blk_key0 TYPE string.
+    DATA bk_len   TYPE i.
+    DATA line     TYPE ty_line.
+
+    " Block-body collection work vars
+    DATA blk_body     TYPE string_table.
+    DATA nn           TYPE i.
+    DATA bbrr         TYPE string.
+    DATA bb_off       TYPE i.
+    DATA bb_len       TYPE i.
+    DATA bb_blank     TYPE abap_bool.
+
+    " Block indent detection
+    DATA blk_ind_col   TYPE i.
+    DATA blk_stripped  TYPE string_table.
+    DATA bsl           TYPE string.
+    DATA bsl_off       TYPE i.
+    DATA bsl_len       TYPE i.
+    DATA strip_from    TYPE i.
+    DATA trailing_blanks TYPE i.
+    DATA tot_stripped  TYPE i.
+    DATA ti            TYPE i.
+    DATA content_lines TYPE i.
+
+    " Block value assembly
+    DATA blk_style TYPE string.
+    DATA blk_chomp TYPE string.
+    DATA blk_val   TYPE string.
+    DATA li        TYPE i.
+    DATA fi        TYPE i.
+    DATA fl        TYPE string.
+    DATA prev_blank TYPE abap_bool.
+    DATA ki        TYPE i.
+    DATA bv_len    TYPE i.
+
+    total = lines( raw ).
+    n     = 1.
+    WHILE n <= total.
+      rr   = raw[ n ].
+      rlen = strlen( rr ).
+      off  = 0.
       " count leading spaces; reject tab in leading whitespace
-      DATA(off) = 0.
-      WHILE off < strlen( r ).
-        CASE r+off(1).
+      WHILE off < rlen.
+        CASE substring( val = rr off = off len = 1 ).
           WHEN ` `.
             off = off + 1.
           WHEN cl_abap_char_utilities=>horizontal_tab.
-            " ponytail: cx_sy_conversion_no_number is the nearest concrete subclass
-            " of cx_sy_conversion_error available on ER1; test catches the parent
+            " ponytail: cx_sy_conversion_no_number nearest concrete subclass
             RAISE EXCEPTION TYPE cx_sy_conversion_no_number
               EXPORTING value = |Tab in indentation at line { n }|.
           WHEN OTHERS.
             EXIT.
         ENDCASE.
       ENDWHILE.
-      DATA(indent) = off.
-      DATA(body)   = r+off.
-      body = strip_comment( body ).
-      body = trim_right( body ).
-      CHECK body IS NOT INITIAL AND body <> `---`.
-      DATA(line) = VALUE ty_line( lineno = n indent = indent content = body ).
+      indent = off.
+      body   = substring( val = rr off = off ).
+      body   = strip_comment( body ).
+      body   = trim_right( body ).
+      IF body IS INITIAL OR body = `---`.
+        n = n + 1.
+        CONTINUE.
+      ENDIF.
+      line = VALUE ty_line( lineno = n indent = indent content = body ).
       IF body = `...`.
         line-doc_marker = abap_true.
+        APPEND line TO lines.
+        n = n + 1.
+        CONTINUE.
       ENDIF.
+
+      " Detect block scalar indicator: |, >, |-, |+, >-, >+
+      blen    = strlen( body ).
+      blk_ind = ``.
+      IF blen >= 2.
+        last2c = substring( val = body off = blen - 2 len = 2 ).
+        IF last2c = `|-` OR last2c = `|+` OR last2c = `>-` OR last2c = `>+`.
+          blk_ind = last2c.
+        ENDIF.
+      ENDIF.
+      IF blk_ind IS INITIAL AND blen >= 1.
+        last1c = substring( val = body off = blen - 1 len = 1 ).
+        IF last1c = `|` OR last1c = `>`.
+          blk_ind = last1c.
+        ENDIF.
+      ENDIF.
+
+      IF blk_ind IS NOT INITIAL.
+        ind_len  = strlen( blk_ind ).
+        " pre_char: the character just before the indicator
+        pre_char = COND string( WHEN blen > ind_len
+                                THEN substring( val = body off = blen - ind_len - 1 len = 1 )
+                                ELSE `` ).
+        blk_key0 = trim_right( substring( val = body len = blen - ind_len ) ).
+        bk_len   = strlen( blk_key0 ).
+        " Only a mapping block header: blk_key0 must end with ':' (and indicator preceded by space)
+        IF ( blen = ind_len OR pre_char = ` ` )
+           AND bk_len > 0
+           AND substring( val = blk_key0 off = bk_len - 1 len = 1 ) = `:`.
+
+          " Collect raw body lines: blank OR indent > header indent
+          CLEAR blk_body.
+          nn = n + 1.
+          WHILE nn <= total.
+            bbrr   = raw[ nn ].
+            bb_len = strlen( bbrr ).
+            bb_off = 0.
+            WHILE bb_off < bb_len AND substring( val = bbrr off = bb_off len = 1 ) = ` `.
+              bb_off = bb_off + 1.
+            ENDWHILE.
+            bb_blank = xsdbool( bb_off = bb_len ).
+            IF bb_blank = abap_true.
+              APPEND bbrr TO blk_body.
+              nn = nn + 1.
+            ELSEIF bb_off > indent.
+              APPEND bbrr TO blk_body.
+              nn = nn + 1.
+            ELSE.
+              EXIT.
+            ENDIF.
+          ENDWHILE.
+
+          " Block indent = indent of first non-blank body line
+          blk_ind_col = 0.
+          LOOP AT blk_body INTO bsl.
+            bsl_off = 0.
+            bsl_len = strlen( bsl ).
+            WHILE bsl_off < bsl_len AND substring( val = bsl off = bsl_off len = 1 ) = ` `.
+              bsl_off = bsl_off + 1.
+            ENDWHILE.
+            IF bsl_off < bsl_len.
+              blk_ind_col = bsl_off.
+              EXIT.
+            ENDIF.
+          ENDLOOP.
+
+          " Strip block indent from each body line
+          CLEAR blk_stripped.
+          LOOP AT blk_body INTO bsl.
+            bsl_off = 0.
+            bsl_len = strlen( bsl ).
+            WHILE bsl_off < bsl_len AND substring( val = bsl off = bsl_off len = 1 ) = ` `.
+              bsl_off = bsl_off + 1.
+            ENDWHILE.
+            IF bsl_off = bsl_len.
+              APPEND `` TO blk_stripped.
+            ELSE.
+              strip_from = COND i( WHEN bsl_off >= blk_ind_col THEN blk_ind_col ELSE bsl_off ).
+              APPEND substring( val = bsl off = strip_from ) TO blk_stripped.
+            ENDIF.
+          ENDLOOP.
+
+          " Count trailing blank lines
+          tot_stripped   = lines( blk_stripped ).
+          trailing_blanks = 0.
+          ti = tot_stripped.
+          WHILE ti >= 1 AND blk_stripped[ ti ] IS INITIAL.
+            trailing_blanks = trailing_blanks + 1.
+            ti = ti - 1.
+          ENDWHILE.
+          content_lines = tot_stripped - trailing_blanks.
+
+          " Fold/join body lines
+          blk_style = substring( val = blk_ind off = 0 len = 1 ).
+          blk_chomp = COND string( WHEN ind_len > 1
+                                   THEN substring( val = blk_ind off = 1 len = 1 )
+                                   ELSE `` ).
+          blk_val = ``.
+          IF blk_style = `|`.
+            " LITERAL: each content line + LF
+            li = 1.
+            WHILE li <= content_lines.
+              blk_val = blk_val && blk_stripped[ li ] && cl_abap_char_utilities=>newline.
+              li = li + 1.
+            ENDWHILE.
+          ELSE.
+            " FOLDED: consecutive non-blank lines joined by space; blank line → LF
+            prev_blank = abap_false.
+            fi = 1.
+            WHILE fi <= content_lines.
+              fl = blk_stripped[ fi ].
+              IF fl IS INITIAL.
+                blk_val    = blk_val && cl_abap_char_utilities=>newline.
+                prev_blank = abap_true.
+              ELSE.
+                IF fi > 1 AND prev_blank = abap_false.
+                  blk_val = blk_val && ` `.
+                ENDIF.
+                blk_val    = blk_val && fl.
+                prev_blank = abap_false.
+              ENDIF.
+              fi = fi + 1.
+            ENDWHILE.
+            IF content_lines > 0.
+              blk_val = blk_val && cl_abap_char_utilities=>newline.
+            ENDIF.
+          ENDIF.
+
+          " Apply chomping
+          CASE blk_chomp.
+            WHEN `-`.
+              " STRIP: remove trailing LF
+              bv_len = strlen( blk_val ).
+              IF bv_len > 0 AND
+                 substring( val = blk_val off = bv_len - 1 len = 1 ) = cl_abap_char_utilities=>newline.
+                blk_val = substring( val = blk_val len = bv_len - 1 ).
+              ENDIF.
+            WHEN `+`.
+              " KEEP: append trailing blank lines as extra LFs
+              ki = 1.
+              WHILE ki <= trailing_blanks.
+                blk_val = blk_val && cl_abap_char_utilities=>newline.
+                ki = ki + 1.
+              ENDWHILE.
+            WHEN OTHERS.
+              " CLIP (default): exactly one trailing LF already emitted — nothing to do
+          ENDCASE.
+
+          line-blk_scalar_hd = abap_true.
+          line-blk_value     = blk_val.
+          line-content       = blk_key0.
+          APPEND line TO lines.
+          n = nn.
+          CONTINUE.
+        ELSE.
+          CLEAR blk_ind.  " not a mapping block header — treat as plain content
+        ENDIF.
+      ENDIF.
+
       APPEND line TO lines.
-    ENDLOOP.
+      n = n + 1.
+    ENDWHILE.
   ENDMETHOD.
 
   METHOD strip_comment.
@@ -124,6 +348,7 @@ CLASS lcl_parser IMPLEMENTATION.
     DATA lv_key    TYPE string.
     DATA lv_inline TYPE string.
     DATA lv_has    TYPE abap_bool.
+    DATA lv_child  TYPE ty_node_ref.
     WHILE idx <= lines( lines ) AND lines[ idx ]-indent = own_indent.
       DATA(cur) = lines[ idx ].
       IF cur-doc_marker = abap_true. idx = idx + 1. EXIT. ENDIF.
@@ -131,10 +356,14 @@ CLASS lcl_parser IMPLEMENTATION.
       split_key_value( EXPORTING content = cur-content lineno = cur-lineno
                        IMPORTING key = lv_key inline_value = lv_inline has_inline = lv_has ).
       idx = idx + 1.
-      DATA(child) = value_or_block( EXPORTING lines = lines own_indent = own_indent
-                                              has_inline = lv_has inline_value = lv_inline
-                                    CHANGING  idx = idx ).
-      lcl_tree=>add_child( node = node key = lv_key child = child ).
+      IF cur-blk_scalar_hd = abap_true.
+        lv_child = lcl_tree=>new_scalar( value = cur-blk_value ).
+      ELSE.
+        lv_child = value_or_block( EXPORTING lines = lines own_indent = own_indent
+                                             has_inline = lv_has inline_value = lv_inline
+                                   CHANGING  idx = idx ).
+      ENDIF.
+      lcl_tree=>add_child( node = node key = lv_key child = lv_child ).
     ENDWHILE.
     " bad-dedent: next line is deeper than own but wasn't consumed
     IF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -847,6 +847,218 @@ CLASS lcl_typed_mapper IMPLEMENTATION.
 ENDCLASS.
 
 CLASS lcl_gen_mapper IMPLEMENTATION.
+
+  METHOD sanitize_name.
+    " uppercase, replace non-alphanumeric/underscore with '_', prefix digit-start with 'F', max 30
+    DATA(raw_up) = to_upper( raw ).
+    DATA(len)    = strlen( raw_up ).
+    DATA lv_out  TYPE string.
+    DATA i       TYPE i.
+    WHILE i < len AND strlen( lv_out ) < 30.
+      DATA(c) = substring( val = raw_up off = i len = 1 ).
+      IF c CO `ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_`.
+        lv_out = lv_out && c.
+      ELSE.
+        lv_out = lv_out && `_`.
+      ENDIF.
+      i = i + 1.
+    ENDWHILE.
+    IF lv_out IS INITIAL.
+      lv_out = `F`.
+    ELSEIF substring( val = lv_out off = 0 len = 1 ) CO `0123456789`.
+      lv_out = `F` && substring( val = lv_out len = COND i( WHEN strlen( lv_out ) < 30 THEN strlen( lv_out ) ELSE 29 ) ).
+    ENDIF.
+    result = lv_out.
+  ENDMETHOD.
+
+  METHOD detect_scalar_type.
+    " Type detection by character checks only (no regex).
+    " null / empty → string
+    DATA(len) = strlen( value ).
+    IF len = 0.
+      CREATE DATA rr_data TYPE string.
+      RETURN.
+    ENDIF.
+
+    " boolean: exact tokens
+    IF value = `true` OR value = `false`.
+      CREATE DATA rr_data TYPE abap_bool.
+      IF value = `true`.
+        ASSIGN rr_data->* TO FIELD-SYMBOL(<b>).
+        <b> = abap_true.
+      ENDIF.
+      RETURN.
+    ENDIF.
+
+    " date: YYYY-MM-DD — exactly 10 chars, '-' at pos 4 and 7, digits elsewhere
+    IF len = 10
+       AND substring( val = value off = 4 len = 1 ) = `-`
+       AND substring( val = value off = 7 len = 1 ) = `-`
+       AND substring( val = value off = 0 len = 4 ) CO `0123456789`
+       AND substring( val = value off = 5 len = 2 ) CO `0123456789`
+       AND substring( val = value off = 8 len = 2 ) CO `0123456789`.
+      CREATE DATA rr_data TYPE d.
+      ASSIGN rr_data->* TO FIELD-SYMBOL(<d>).
+      DATA(dstr) = substring( val = value off = 0 len = 4 )
+                && substring( val = value off = 5 len = 2 )
+                && substring( val = value off = 8 len = 2 ).
+      <d> = dstr.
+      RETURN.
+    ENDIF.
+
+    " integer: optional leading '-', then 1-9 digits, no dot
+    " ponytail: 10+ digit integers (absolute value) fall back to string to avoid i overflow
+    DATA(scan_off) = 0.
+    IF substring( val = value off = 0 len = 1 ) = `-`.
+      scan_off = 1.
+    ENDIF.
+    DATA(digit_len) = len - scan_off.
+    IF digit_len >= 1
+       AND digit_len <= 9
+       AND substring( val = value off = scan_off ) CO `0123456789`.
+      CREATE DATA rr_data TYPE i.
+      ASSIGN rr_data->* TO FIELD-SYMBOL(<i>).
+      <i> = value.
+      RETURN.
+    ENDIF.
+
+    " decimal: optional '-', digits, single '.', digits — no further dots
+    " ponytail: uses decfloat34 (64-bit, sufficient for YAML numerics)
+    DATA dot_pos TYPE i.
+    DATA di      TYPE i.
+    DATA d_off   TYPE i.
+    dot_pos = -1.
+    d_off   = 0.
+    IF substring( val = value off = 0 len = 1 ) = `-`.
+      d_off = 1.
+    ENDIF.
+    di = d_off.
+    WHILE di < len.
+      DATA(dc) = substring( val = value off = di len = 1 ).
+      IF dc = `.`.
+        IF dot_pos >= 0.
+          " second dot → not a number
+          dot_pos = -1.
+          EXIT.
+        ENDIF.
+        dot_pos = di.
+      ELSEIF NOT ( dc CO `0123456789` ).
+        dot_pos = -1.
+        EXIT.
+      ENDIF.
+      di = di + 1.
+    ENDWHILE.
+    IF dot_pos > d_off AND dot_pos < len - 1.
+      " dot is not at start and not at end
+      CREATE DATA rr_data TYPE decfloat34.
+      ASSIGN rr_data->* TO FIELD-SYMBOL(<df>).
+      <df> = value.
+      RETURN.
+    ENDIF.
+
+    " fallback: string
+    CREATE DATA rr_data TYPE string.
+    ASSIGN rr_data->* TO FIELD-SYMBOL(<s>).
+    <s> = value.
+  ENDMETHOD.
+
+  METHOD generate.
+    CASE node->node-kind.
+
+      WHEN c_node=>scalar.
+        " leaf: detect type and return typed data ref
+        IF node->node-is_null = abap_true.
+          CREATE DATA rr_data TYPE string.
+          RETURN.
+        ENDIF.
+        rr_data = detect_scalar_type( node->node-value ).
+
+      WHEN c_node=>mapping.
+        " Build a dynamic structure: one component per child, typed from recursive generate()
+        DATA lt_comps   TYPE cl_abap_structdescr=>component_table.
+        DATA lt_refs    TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY.
+        LOOP AT node->children INTO DATA(child).
+          DATA(comp_name) = sanitize_name( child-key ).
+          " recursively generate child value to get its type
+          DATA(child_ref) = generate( child-node ).
+          DATA(child_td)  = cl_abap_typedescr=>describe_by_data_ref( child_ref ).
+          APPEND VALUE abap_componentdescr( name = comp_name
+                                            type = CAST cl_abap_datadescr( child_td ) )
+                 TO lt_comps.
+          APPEND child_ref TO lt_refs.
+        ENDLOOP.
+        IF lt_comps IS INITIAL.
+          " empty mapping → empty structure
+          CREATE DATA rr_data TYPE string.
+          RETURN.
+        ENDIF.
+        DATA(struct_td) = cl_abap_structdescr=>create( lt_comps ).
+        CREATE DATA rr_data TYPE HANDLE struct_td.
+        " fill each component from the pre-generated child refs
+        ASSIGN rr_data->* TO FIELD-SYMBOL(<struct>).
+        DATA(ci) = 1.
+        LOOP AT node->children INTO DATA(fill_child).
+          DATA(fill_name) = sanitize_name( fill_child-key ).
+          ASSIGN COMPONENT fill_name OF STRUCTURE <struct> TO FIELD-SYMBOL(<comp>).
+          IF sy-subrc = 0.
+            DATA(fill_ref) = lt_refs[ ci ].
+            ASSIGN fill_ref->* TO FIELD-SYMBOL(<val>).
+            <comp> = <val>.
+          ENDIF.
+          ci = ci + 1.
+        ENDLOOP.
+
+      WHEN c_node=>sequence.
+        " Build typed table: detect element type from first child, fall back to string if mixed
+        DATA(child_count) = lines( node->children ).
+        IF child_count = 0.
+          " empty sequence → string table
+          DATA(empty_line_td) = CAST cl_abap_datadescr(
+                                  cl_abap_typedescr=>describe_by_name( `STRING` ) ).
+          DATA(empty_tab_td) = cl_abap_tabledescr=>create( empty_line_td ).
+          CREATE DATA rr_data TYPE HANDLE empty_tab_td.
+          RETURN.
+        ENDIF.
+        " generate first child to detect line type
+        DATA(first_child_node) = node->children[ 1 ]-node.
+        DATA(first_ref)        = generate( first_child_node ).
+        DATA(first_td)         = cl_abap_typedescr=>describe_by_data_ref( first_ref ).
+        DATA(line_type_td)     = CAST cl_abap_datadescr( first_td ).
+        " ponytail: type uniformity check — only verify kind matches (not full type equality).
+        " Mixed-kind sequences fall back to string table.
+        DATA lv_uniform TYPE abap_bool VALUE abap_true.
+        DATA li TYPE i VALUE 2.
+        WHILE li <= child_count AND lv_uniform = abap_true.
+          DATA(chk_ref) = generate( node->children[ li ]-node ).
+          DATA(chk_td)  = cl_abap_typedescr=>describe_by_data_ref( chk_ref ).
+          IF chk_td->kind <> first_td->kind.
+            lv_uniform = abap_false.
+          ENDIF.
+          li = li + 1.
+        ENDWHILE.
+        IF lv_uniform = abap_false.
+          " mixed kinds → string table
+          DATA(fb_line_td) = CAST cl_abap_datadescr(
+                               cl_abap_typedescr=>describe_by_name( `STRING` ) ).
+          line_type_td = fb_line_td.
+        ENDIF.
+        DATA(tab_td) = cl_abap_tabledescr=>create( line_type_td ).
+        CREATE DATA rr_data TYPE HANDLE tab_td.
+        ASSIGN rr_data->* TO FIELD-SYMBOL(<table>).
+        " re-generate all children and append (first_ref already done; re-use it)
+        ASSIGN first_ref->* TO FIELD-SYMBOL(<row0>).
+        INSERT <row0> INTO TABLE <table>.
+        li = 2.
+        WHILE li <= child_count.
+          DATA(row_ref) = generate( node->children[ li ]-node ).
+          ASSIGN row_ref->* TO FIELD-SYMBOL(<row>).
+          INSERT <row> INTO TABLE <table>.
+          li = li + 1.
+        ENDWHILE.
+
+    ENDCASE.
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS lcl_emitter IMPLEMENTATION.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -89,22 +89,15 @@ CLASS lcl_scanner IMPLEMENTATION.
     WHILE n <= total.
       lv_raw_line   = raw[ n ].
       rlen = strlen( lv_raw_line ).
-      off  = 0.
-      " count leading spaces; reject tab in leading whitespace
-      WHILE off < rlen.
-        CASE substring( val = lv_raw_line off = off len = 1 ).
-          WHEN ` `.
-            off = off + 1.
-          WHEN cl_abap_char_utilities=>horizontal_tab.
-            " ponytail: cx_sy_conversion_no_number nearest concrete subclass
-            RAISE EXCEPTION TYPE cx_sy_conversion_no_number
-              EXPORTING value = |Tab in indentation at line { n }|.
-          WHEN OTHERS.
-            EXIT.
-        ENDCASE.
-      ENDWHILE.
-      indent = off.
-      body   = substring( val = lv_raw_line off = off ).
+      body = lv_raw_line.
+      SHIFT body LEFT DELETING LEADING ` `.
+      indent = rlen - strlen( body ).
+      IF strlen( body ) > 0
+         AND substring( val = body off = 0 len = 1 ) = cl_abap_char_utilities=>horizontal_tab.
+        " ponytail: cx_sy_conversion_no_number nearest concrete subclass
+        RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+          EXPORTING value = |Tab in indentation at line { n }|.
+      ENDIF.
       body   = strip_comment( body ).
       body   = trim_right( body ).
       IF body IS INITIAL OR body = `---`.
@@ -319,6 +312,11 @@ CLASS lcl_scanner IMPLEMENTATION.
   METHOD strip_comment.
     " '#' preceded by whitespace (or at pos 0) -- strip from there
     " Quote-aware: skip '#' inside single or double quotes
+    " fast-path: no '#' in line → no comment possible
+    IF NOT ( body CS `#` ).
+      result = body.
+      RETURN.
+    ENDIF.
     DATA in_sq TYPE abap_bool.
     DATA in_dq TYPE abap_bool.
     DATA(len) = strlen( body ).

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -78,6 +78,132 @@ CLASS lcl_scanner IMPLEMENTATION.
 ENDCLASS.
 
 CLASS lcl_parser IMPLEMENTATION.
+
+  METHOD parse.
+    DATA(idx) = 1.
+    IF lines IS INITIAL.
+      root = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
+      RETURN.
+    ENDIF.
+    root = parse_block( EXPORTING lines = lines CHANGING idx = idx ).
+  ENDMETHOD.
+
+  METHOD parse_block.
+    DATA(own)   = lines[ idx ]-indent.
+    DATA(first) = lines[ idx ]-content.
+    IF first CP `- *` OR first = `-`.
+      node = parse_sequence( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
+    ELSEIF first CA `:`.
+      node = parse_mapping( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
+    ELSE.
+      " plain scalar line
+      node = lcl_tree=>new_scalar( value = first ).
+      idx = idx + 1.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD parse_mapping.
+    node = lcl_tree=>new_collection( c_node=>mapping ).
+    DATA lv_key    TYPE string.
+    DATA lv_inline TYPE string.
+    DATA lv_has    TYPE abap_bool.
+    WHILE idx <= lines( lines ) AND lines[ idx ]-indent = own_indent.
+      DATA(cur) = lines[ idx ].
+      IF cur-doc_marker = abap_true. idx = idx + 1. EXIT. ENDIF.
+      IF cur-content CP `- *` OR cur-content = `-`. EXIT. ENDIF.
+      split_key_value( EXPORTING content = cur-content lineno = cur-lineno
+                       IMPORTING key = lv_key inline_value = lv_inline has_inline = lv_has ).
+      idx = idx + 1.
+      DATA(child) = value_or_block( EXPORTING lines = lines own_indent = own_indent
+                                              has_inline = lv_has inline_value = lv_inline
+                                    CHANGING  idx = idx ).
+      lcl_tree=>add_child( node = node key = lv_key child = child ).
+    ENDWHILE.
+    " bad-dedent: next line is deeper than own but wasn't consumed
+    IF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
+      RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+        EXPORTING value = |Bad indentation at line { lines[ idx ]-lineno }|.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD parse_sequence.
+    node = lcl_tree=>new_collection( c_node=>sequence ).
+    WHILE idx <= lines( lines ) AND lines[ idx ]-indent = own_indent
+          AND ( lines[ idx ]-content CP `- *` OR lines[ idx ]-content = `-` ).
+      DATA(c)    = lines[ idx ]-content.
+      DATA(rest) = COND string( WHEN c = `-` THEN ``
+                                ELSE substring( val = c off = 2 ) ).
+      DATA(child) = parse_seq_item( EXPORTING lines = lines own_indent = own_indent rest = rest
+                                    CHANGING  idx = idx ).
+      lcl_tree=>add_child( node = node child = child ).
+    ENDWHILE.
+  ENDMETHOD.
+
+  METHOD parse_seq_item.
+    " advance past the dash line
+    idx = idx + 1.
+    " Build virtual sub-lines for this item:
+    "   first entry: rest text at indent = own_indent + 2
+    "   following:   continuation lines with indent > own_indent, copied as-is
+    DATA sub TYPE ty_lines.
+    IF rest IS NOT INITIAL.
+      APPEND VALUE ty_line( lineno = 0 indent = own_indent + 2 content = rest ) TO sub.
+    ENDIF.
+    WHILE idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
+      APPEND lines[ idx ] TO sub.
+      idx = idx + 1.
+    ENDWHILE.
+    IF sub IS INITIAL.
+      " bare `-` with nothing below → null scalar
+      node = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
+      RETURN.
+    ENDIF.
+    DATA(sub_idx) = 1.
+    node = parse_block( EXPORTING lines = sub CHANGING idx = sub_idx ).
+  ENDMETHOD.
+
+  METHOD split_key_value.
+    DATA len TYPE i.
+    DATA i   TYPE i.
+    len = strlen( content ).
+    WHILE i < len.
+      DATA(ch) = substring( val = content off = i len = 1 ).
+      IF ch = `:`.
+        DATA(next_pos) = i + 1.
+        IF next_pos >= len.
+          " key: (nothing after colon)
+          key        = substring( val = content len = i ).
+          has_inline = abap_false.
+          RETURN.
+        ENDIF.
+        DATA(next_ch) = substring( val = content off = next_pos len = 1 ).
+        IF next_ch = ` `.
+          key = substring( val = content len = i ).
+          DATA(val_off) = i + 2.
+          IF val_off < len.
+            inline_value = substring( val = content off = val_off ).
+          ENDIF.
+          has_inline = abap_true.
+          RETURN.
+        ENDIF.
+      ENDIF.
+      i = i + 1.
+    ENDWHILE.
+    " no ':' found — treat whole content as key
+    key        = content.
+    has_inline = abap_false.
+  ENDMETHOD.
+
+  METHOD value_or_block.
+    IF has_inline = abap_true.
+      node = lcl_tree=>new_scalar( value = inline_value ).
+    ELSEIF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
+      node = parse_block( EXPORTING lines = lines CHANGING idx = idx ).
+    ELSE.
+      node = lcl_tree=>new_scalar( value = `` is_null = abap_true ).
+    ENDIF.
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS lcl_typed_mapper IMPLEMENTATION.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -93,12 +93,16 @@ CLASS lcl_parser IMPLEMENTATION.
     DATA(first) = lines[ idx ]-content.
     IF first CP `- *` OR first = `-`.
       node = parse_sequence( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
-    ELSEIF first CA `:`.
-      node = parse_mapping( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
     ELSE.
-      " plain scalar line
-      node = lcl_tree=>new_scalar( value = first ).
-      idx = idx + 1.
+      DATA lv_is_mapping TYPE abap_bool.
+      split_key_value( EXPORTING content = first lineno = lines[ idx ]-lineno
+                       IMPORTING is_mapping = lv_is_mapping ).
+      IF lv_is_mapping = abap_true.
+        node = parse_mapping( EXPORTING lines = lines own_indent = own CHANGING idx = idx ).
+      ELSE.
+        node = lcl_tree=>new_scalar( value = first ).
+        idx = idx + 1.
+      ENDIF.
     ENDIF.
   ENDMETHOD.
 
@@ -137,6 +141,11 @@ CLASS lcl_parser IMPLEMENTATION.
                                     CHANGING  idx = idx ).
       lcl_tree=>add_child( node = node child = child ).
     ENDWHILE.
+    " bad-dedent: next line is deeper than own but wasn't consumed
+    IF idx <= lines( lines ) AND lines[ idx ]-indent > own_indent.
+      RAISE EXCEPTION TYPE cx_sy_conversion_no_number
+        EXPORTING value = |Bad indentation at line { lines[ idx ]-lineno }|.
+    ENDIF.
   ENDMETHOD.
 
   METHOD parse_seq_item.
@@ -172,8 +181,10 @@ CLASS lcl_parser IMPLEMENTATION.
         DATA(next_pos) = i + 1.
         IF next_pos >= len.
           " key: (nothing after colon)
-          key        = substring( val = content len = i ).
-          has_inline = abap_false.
+          key          = substring( val = content len = i ).
+          inline_value = ``.
+          has_inline   = abap_false.
+          is_mapping   = abap_true.
           RETURN.
         ENDIF.
         DATA(next_ch) = substring( val = content off = next_pos len = 1 ).
@@ -184,14 +195,16 @@ CLASS lcl_parser IMPLEMENTATION.
             inline_value = substring( val = content off = val_off ).
           ENDIF.
           has_inline = abap_true.
+          is_mapping = abap_true.
           RETURN.
         ENDIF.
       ENDIF.
       i = i + 1.
     ENDWHILE.
-    " no ':' found — treat whole content as key
+    " no valid key separator found — plain scalar
     key        = content.
     has_inline = abap_false.
+    is_mapping = abap_false.
   ENDMETHOD.
 
   METHOD value_or_block.

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -1198,9 +1198,16 @@ CLASS lcl_emitter IMPLEMENTATION.
           WHEN cl_abap_typedescr=>typekind_bool.
             result = COND string( WHEN <elem> = abap_true THEN `true` ELSE `false` ).
           WHEN cl_abap_typedescr=>typekind_char.
-            " abap_bool (c len 1) is already handled above; other c-type: treat as string
+            " ponytail: abap_bool is c len 1 so typekind_char fires, not typekind_bool.
+            " Check type name against known ABAP boolean types; emit true/false for those.
             lv_raw = <elem>.
-            result = quote_scalar( value = lv_raw quote_style = quote_style ).
+            IF eld->absolute_name CP `*ABAP_BOOL*` OR eld->absolute_name CP `*BOOLEAN*`
+               OR eld->absolute_name CP `*BOOLE_D*`  OR eld->absolute_name CP `*XFELD*`
+               OR eld->absolute_name CP `*XSDBOOLEAN*`.
+              result = COND string( WHEN lv_raw = abap_true THEN `true` ELSE `false` ).
+            ELSE.
+              result = quote_scalar( value = lv_raw quote_style = quote_style ).
+            ENDIF.
           WHEN cl_abap_typedescr=>typekind_string.
             lv_raw = <elem>.
             result = quote_scalar( value = lv_raw quote_style = quote_style ).

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -1222,10 +1222,23 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
           DATA(chk_ref) = generate( node->children[ li ]-node ).
           APPEND chk_ref TO lt_child_refs.
           DATA(chk_td)  = cl_abap_typedescr=>describe_by_data_ref( chk_ref ).
-          IF chk_td->kind <> first_td->kind
-             OR chk_td->absolute_name <> first_td->absolute_name.
+          IF chk_td->kind <> first_td->kind.
             lv_uniform = abap_false.
+          ELSEIF chk_td->kind = cl_abap_typedescr=>kind_elem.
+            " For elementary: absolute_name must match (preserves Phase B fix: int vs decfloat → non-uniform)
+            IF chk_td->absolute_name <> first_td->absolute_name.
+              lv_uniform = abap_false.
+            ENDIF.
+          ELSEIF chk_td->kind = cl_abap_typedescr=>kind_struct.
+            " For structures: compare component layout — dynamic structs always differ by absolute_name
+            " ponytail: component comparison works for flat elementary fields (RTTI singletons);
+            "           nested dynamic struct fields differ by ref identity → falls through to REF TO data fallback
+            IF CAST cl_abap_structdescr( chk_td )->components <>
+               CAST cl_abap_structdescr( first_td )->components.
+              lv_uniform = abap_false.
+            ENDIF.
           ENDIF.
+          " For kind_table: kind match is sufficient (uniform by kind)
           li = li + 1.
         ENDWHILE.
         IF lv_uniform = abap_false.
@@ -1244,12 +1257,15 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
             INSERT <row> INTO TABLE <table>.
           ENDLOOP.
         ELSE.
-          " non-uniform fallback is string table — convert each value via string
+          " non-uniform fallback: string table for elementary values; skip deep (struct/table) elements
           DATA lv_sval TYPE string.
           LOOP AT lt_child_refs INTO DATA(row_ref2).
             ASSIGN row_ref2->* TO FIELD-SYMBOL(<rval>).
-            lv_sval = <rval>.
-            INSERT lv_sval INTO TABLE <table>.
+            DATA(rval_td) = cl_abap_typedescr=>describe_by_data( <rval> ).
+            IF rval_td->kind = cl_abap_typedescr=>kind_elem.
+              lv_sval = <rval>.
+              INSERT lv_sval INTO TABLE <table>.
+            ENDIF.
           ENDLOOP.
         ENDIF.
 

--- a/src/z_ui2_yaml.clas.locals_imp.abap
+++ b/src/z_ui2_yaml.clas.locals_imp.abap
@@ -8,6 +8,22 @@ CLASS lcl_node_ref IMPLEMENTATION.
 ENDCLASS.
 
 CLASS lcl_tree IMPLEMENTATION.
+  METHOD is_bool_type.
+    result = xsdbool(
+      eld->absolute_name CP `*ABAP_BOOL*`  OR eld->absolute_name CP `*BOOLEAN*`
+      OR eld->absolute_name CP `*BOOLE_D*` OR eld->absolute_name CP `*XFELD*`
+      OR eld->absolute_name CP `*XSDBOOLEAN*` ).
+  ENDMETHOD.
+  METHOD is_date_like.
+    DATA(len) = strlen( value ).
+    result = xsdbool(
+      len = 10
+      AND substring( val = value off = 4 len = 1 ) = `-`
+      AND substring( val = value off = 7 len = 1 ) = `-`
+      AND substring( val = value off = 0 len = 4 ) CO `0123456789`
+      AND substring( val = value off = 5 len = 2 ) CO `0123456789`
+      AND substring( val = value off = 8 len = 2 ) CO `0123456789` ).
+  ENDMETHOD.
   METHOD new_scalar.
     node = NEW lcl_node_ref( ).
     node->node = VALUE ty_node( kind = c_node=>scalar value = value is_null = is_null ).
@@ -167,8 +183,7 @@ CLASS lcl_scanner IMPLEMENTATION.
             ENDWHILE.
             blk_anchor_cand = substring( val = blk_after_colon off = 1 len = blk_an_end - 1 ).
             IF blk_anchor_cand IS NOT INITIAL
-               AND blk_anchor_cand CO
-                 `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-`.
+               AND blk_anchor_cand CO lcl_tree=>c_yaml_name_chars.
               line-blk_anchor = blk_anchor_cand.
               blk_key0 = substring( val = blk_key0 len = blk_colon_pos + 1 ).
             ENDIF.
@@ -349,11 +364,12 @@ CLASS lcl_scanner IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD trim_right.
-    result = body.
-    WHILE strlen( result ) > 0
-      AND substring( val = result off = strlen( result ) - 1 len = 1 ) = ` `.
-      result = substring( val = result len = strlen( result ) - 1 ).
+    DATA n TYPE i.
+    n = strlen( body ).
+    WHILE n > 0 AND substring( val = body off = n - 1 len = 1 ) = ` `.
+      n = n - 1.
     ENDWHILE.
+    result = substring( val = body len = n ).
   ENDMETHOD.
 
   METHOD trim.
@@ -423,6 +439,10 @@ CLASS lcl_parser IMPLEMENTATION.
     ENDLOOP.
     IF cur_block IS NOT INITIAL.
       APPEND cur_block TO rt_blocks.
+    ENDIF.
+    " no doc boundaries found → wrap whole input as single block
+    IF rt_blocks IS INITIAL AND lines IS NOT INITIAL.
+      APPEND lines TO rt_blocks.
     ENDIF.
   ENDMETHOD.
 
@@ -596,7 +616,7 @@ CLASS lcl_parser IMPLEMENTATION.
                                       THEN substring( val = trimmed off = 1 ) ELSE `` ).
       IF strlen( trimmed ) > 1
          AND substring( val = trimmed off = 0 len = 1 ) = `*`
-         AND alias_rest CO `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-`.
+         AND alias_rest CO lcl_tree=>c_yaml_name_chars.
         node = resolve_alias( raw = trimmed lineno = 0 ).
         RETURN.
       ENDIF.
@@ -860,8 +880,7 @@ CLASS lcl_parser IMPLEMENTATION.
     ENDWHILE.
     DATA(candidate) = substring( val = raw off = 1 len = i - 1 ).
     IF candidate IS INITIAL
-       OR NOT ( candidate CO
-         `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-` ).
+       OR NOT ( candidate CO lcl_tree=>c_yaml_name_chars ).
       RETURN.
     ENDIF.
     aname = candidate.
@@ -965,9 +984,7 @@ CLASS lcl_typed_mapper IMPLEMENTATION.
         ENDIF.
         " bool target: map true/false/x → abap_true/abap_false
         DATA(eld2) = CAST cl_abap_elemdescr( td ).
-        IF eld2->absolute_name CP `*ABAP_BOOL*` OR eld2->absolute_name CP `*BOOLEAN*`
-           OR eld2->absolute_name CP `*BOOLE_D*`  OR eld2->absolute_name CP `*XFELD*`
-           OR eld2->absolute_name CP `*XSDBOOLEAN*`.
+        IF lcl_tree=>is_bool_type( eld2 ) = abap_true.
           DATA(lv_lower) = to_lower( node->node-value ).
           IF lv_lower = `true` OR lv_lower = `x`.
             data = abap_true.
@@ -1062,12 +1079,7 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
     ENDIF.
 
     " date: YYYY-MM-DD — exactly 10 chars, '-' at pos 4 and 7, digits elsewhere
-    IF len = 10
-       AND substring( val = value off = 4 len = 1 ) = `-`
-       AND substring( val = value off = 7 len = 1 ) = `-`
-       AND substring( val = value off = 0 len = 4 ) CO `0123456789`
-       AND substring( val = value off = 5 len = 2 ) CO `0123456789`
-       AND substring( val = value off = 8 len = 2 ) CO `0123456789`.
+    IF lcl_tree=>is_date_like( value ) = abap_true.
       CREATE DATA rr_data TYPE d.
       ASSIGN rr_data->* TO FIELD-SYMBOL(<d>).
       DATA(dstr) = substring( val = value off = 0 len = 4 )
@@ -1217,10 +1229,13 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
         DATA(line_type_td)     = CAST cl_abap_datadescr( first_td ).
         " ponytail: type uniformity check — only verify kind matches (not full type equality).
         " Mixed-kind sequences fall back to string table.
+        DATA lt_child_refs TYPE STANDARD TABLE OF REF TO data WITH DEFAULT KEY.
+        APPEND first_ref TO lt_child_refs.
         DATA lv_uniform TYPE abap_bool VALUE abap_true.
         DATA li TYPE i VALUE 2.
         WHILE li <= child_count AND lv_uniform = abap_true.
           DATA(chk_ref) = generate( node->children[ li ]-node ).
+          APPEND chk_ref TO lt_child_refs.
           DATA(chk_td)  = cl_abap_typedescr=>describe_by_data_ref( chk_ref ).
           IF chk_td->kind <> first_td->kind.
             lv_uniform = abap_false.
@@ -1236,16 +1251,11 @@ CLASS lcl_gen_mapper IMPLEMENTATION.
         DATA(tab_td) = cl_abap_tabledescr=>create( line_type_td ).
         CREATE DATA rr_data TYPE HANDLE tab_td.
         ASSIGN rr_data->* TO FIELD-SYMBOL(<table>).
-        " re-generate all children and append (first_ref already done; re-use it)
-        ASSIGN first_ref->* TO FIELD-SYMBOL(<row0>).
-        INSERT <row0> INTO TABLE <table>.
-        li = 2.
-        WHILE li <= child_count.
-          DATA(row_ref) = generate( node->children[ li ]-node ).
+        " fill from collected refs — no regeneration needed
+        LOOP AT lt_child_refs INTO DATA(row_ref).
           ASSIGN row_ref->* TO FIELD-SYMBOL(<row>).
           INSERT <row> INTO TABLE <table>.
-          li = li + 1.
-        ENDWHILE.
+        ENDLOOP.
 
     ENDCASE.
   ENDMETHOD.
@@ -1372,9 +1382,7 @@ CLASS lcl_emitter IMPLEMENTATION.
             " ponytail: abap_bool is c len 1 so typekind_char fires, not typekind_bool.
             " Check type name against known ABAP boolean types; emit true/false for those.
             lv_raw = <elem>.
-            IF eld->absolute_name CP `*ABAP_BOOL*` OR eld->absolute_name CP `*BOOLEAN*`
-               OR eld->absolute_name CP `*BOOLE_D*`  OR eld->absolute_name CP `*XFELD*`
-               OR eld->absolute_name CP `*XSDBOOLEAN*`.
+            IF lcl_tree=>is_bool_type( eld ) = abap_true.
               result = COND string( WHEN lv_raw = abap_true THEN `true` ELSE `false` ).
             ELSE.
               result = quote_scalar( value = lv_raw quote_style = quote_style ).
@@ -1418,12 +1426,13 @@ CLASS lcl_emitter IMPLEMENTATION.
         result = comp_name.
       WHEN z_ui2_yaml=>pretty_mode-low_case.
         result = raw.
-      WHEN z_ui2_yaml=>pretty_mode-camel_case.
-        " MY_FIELD → myField
+      WHEN z_ui2_yaml=>pretty_mode-camel_case OR z_ui2_yaml=>pretty_mode-pascal_case.
+        " MY_FIELD → myField (camel) or MyField (pascal)
         DATA lv_out TYPE string.
-        DATA lv_cap TYPE abap_bool VALUE abap_false.
+        DATA lv_cap TYPE abap_bool.
         DATA i TYPE i.
         DATA(len) = strlen( raw ).
+        lv_cap = xsdbool( pretty_name = z_ui2_yaml=>pretty_mode-pascal_case ).
         WHILE i < len.
           DATA(c) = substring( val = raw off = i len = 1 ).
           IF c = `_`.
@@ -1439,60 +1448,9 @@ CLASS lcl_emitter IMPLEMENTATION.
           i = i + 1.
         ENDWHILE.
         result = lv_out.
-      WHEN z_ui2_yaml=>pretty_mode-pascal_case.
-        DATA lv_out2 TYPE string.
-        DATA lv_cap2 TYPE abap_bool VALUE abap_true.
-        DATA j TYPE i.
-        DATA(len2) = strlen( raw ).
-        WHILE j < len2.
-          DATA(c2) = substring( val = raw off = j len = 1 ).
-          IF c2 = `_`.
-            lv_cap2 = abap_true.
-          ELSE.
-            IF lv_cap2 = abap_true.
-              lv_out2 = lv_out2 && to_upper( c2 ).
-              lv_cap2 = abap_false.
-            ELSE.
-              lv_out2 = lv_out2 && c2.
-            ENDIF.
-          ENDIF.
-          j = j + 1.
-        ENDWHILE.
-        result = lv_out2.
       WHEN OTHERS.
         result = comp_name.
     ENDCASE.
-  ENDMETHOD.
-
-  METHOD looks_like_number.
-    DATA(len) = strlen( value ).
-    IF len = 0. RETURN. ENDIF.
-    DATA off TYPE i.
-    IF substring( val = value off = 0 len = 1 ) = `-`. off = 1. ENDIF.
-    DATA(rem) = len - off.
-    IF rem = 0. RETURN. ENDIF.
-    " integer: all digits (1-9 digits: avoid huge numbers causing issues for round-trip)
-    DATA(digits_only) = substring( val = value off = off ).
-    IF digits_only CO `0123456789`.
-      result = abap_true.
-      RETURN.
-    ENDIF.
-    " decimal: digits dot digits
-    DATA dot_seen TYPE abap_bool VALUE abap_false.
-    DATA di TYPE i VALUE 0.
-    WHILE di < strlen( digits_only ).
-      DATA(dc) = substring( val = digits_only off = di len = 1 ).
-      IF dc = `.`.
-        IF dot_seen = abap_true. RETURN. ENDIF.
-        dot_seen = abap_true.
-      ELSEIF NOT ( dc CO `0123456789` ).
-        RETURN.
-      ENDIF.
-      di = di + 1.
-    ENDWHILE.
-    IF dot_seen = abap_true AND di > 1.
-      result = abap_true.
-    ENDIF.
   ENDMETHOD.
 
   METHOD quote_scalar.
@@ -1546,20 +1504,37 @@ CLASS lcl_emitter IMPLEMENTATION.
     ENDIF.
 
     IF lv_need = abap_false.
-      IF looks_like_number( value ) = abap_true.
-        lv_need = abap_true.
+      " looks like a number? (integer: all digits after optional '-'; decimal: digits.digits)
+      DATA(num_off) = 0.
+      IF len > 0 AND substring( val = value off = 0 len = 1 ) = `-`. num_off = 1. ENDIF.
+      DATA(num_rem) = len - num_off.
+      IF num_rem > 0.
+        DATA(num_rest) = substring( val = value off = num_off ).
+        IF num_rest CO `0123456789`.
+          lv_need = abap_true.
+        ELSE.
+          DATA dot_seen TYPE abap_bool.
+          DATA ndi TYPE i.
+          WHILE ndi < strlen( num_rest ).
+            DATA(ndc) = substring( val = num_rest off = ndi len = 1 ).
+            IF ndc = `.`.
+              IF dot_seen = abap_true. EXIT. ENDIF.
+              dot_seen = abap_true.
+            ELSEIF NOT ( ndc CO `0123456789` ).
+              EXIT.
+            ENDIF.
+            ndi = ndi + 1.
+          ENDWHILE.
+          IF dot_seen = abap_true AND ndi = strlen( num_rest ) AND ndi > 1.
+            lv_need = abap_true.
+          ENDIF.
+        ENDIF.
       ENDIF.
     ENDIF.
 
     " date-like: YYYY-MM-DD
-    IF lv_need = abap_false AND len = 10.
-      IF substring( val = value off = 4 len = 1 ) = `-`
-         AND substring( val = value off = 7 len = 1 ) = `-`
-         AND substring( val = value off = 0 len = 4 ) CO `0123456789`
-         AND substring( val = value off = 5 len = 2 ) CO `0123456789`
-         AND substring( val = value off = 8 len = 2 ) CO `0123456789`.
-        lv_need = abap_true.
-      ENDIF.
+    IF lv_need = abap_false AND lcl_tree=>is_date_like( value ) = abap_true.
+      lv_need = abap_true.
     ENDIF.
 
     IF lv_need = abap_true.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -366,6 +366,7 @@ CLASS ltc_gen DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS gen_sequence                FOR TESTING.
     METHODS gen_dup_sanitized_keys      FOR TESTING.
     METHODS gen_structural_error_fatal  FOR TESTING.
+    METHODS gen_nonuniform_seq_keeps_all FOR TESTING.
 ENDCLASS.
 CLASS ltc_gen IMPLEMENTATION.
   METHOD gen_mapping_field.
@@ -413,6 +414,13 @@ CLASS ltc_gen IMPLEMENTATION.
         cl_abap_unit_assert=>fail( `expected structural error to propagate` ).
       CATCH cx_sy_conversion_error.
     ENDTRY.
+  ENDMETHOD.
+  METHOD gen_nonuniform_seq_keeps_all.
+    " non-uniform sequence (int/bool/int/int): all 4 elements must survive (regression for #6 fix)
+    DATA(r) = z_ui2_yaml=>generate( |- 1\n- true\n- 2\n- 3| ).
+    FIELD-SYMBOLS <t> TYPE ANY TABLE.
+    ASSIGN r->* TO <t>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <t> ) exp = 4 ).
   ENDMETHOD.
 ENDCLASS.
 

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -195,3 +195,31 @@ CLASS ltc_parser IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `http://example.com` ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_block_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS literal_keeps_newlines FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS folded_joins_lines     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS strip_chomp            FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS keep_chomp             FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS v IMPORTING t TYPE string RETURNING VALUE(r) TYPE string RAISING cx_sy_conversion_error.
+ENDCLASS.
+CLASS ltc_block_scalar IMPLEMENTATION.
+  METHOD v.
+    DATA(root) = lcl_parser=>parse( lcl_scanner=>scan( t ) ).
+    r = root->children[ 1 ]-node->node-value.
+  ENDMETHOD.
+  METHOD literal_keeps_newlines.
+    cl_abap_unit_assert=>assert_equals( act = v( |k: \|\n  line1\n  line2| ) exp = |line1\nline2\n| ).
+  ENDMETHOD.
+  METHOD folded_joins_lines.
+    cl_abap_unit_assert=>assert_equals( act = v( |k: >\n  line1\n  line2| ) exp = |line1 line2\n| ).
+  ENDMETHOD.
+  METHOD strip_chomp.
+    cl_abap_unit_assert=>assert_equals( act = v( |k: \|-\n  line1| ) exp = `line1` ).
+  ENDMETHOD.
+  METHOD keep_chomp.
+    " |+ keeps trailing blank line -> "line1\n\n"
+    cl_abap_unit_assert=>assert_equals( act = v( |k: \|+\n  line1\n| ) exp = |line1\n\n| ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -68,6 +68,54 @@ CLASS ltc_tree IMPLEMENTATION.
   ENDMETHOD.
 ENDCLASS.
 
+CLASS ltc_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS single_quote       FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS double_escapes     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS tilde_is_null      FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS flow_map           FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS flow_seq           FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS colon_in_quotes    FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS unterminated_fails FOR TESTING.
+ENDCLASS.
+CLASS ltc_scalar IMPLEMENTATION.
+  METHOD single_quote.
+    lcl_parser=>resolve_scalar( EXPORTING raw = `'it''s'` IMPORTING value = DATA(v) is_null = DATA(n) ).
+    cl_abap_unit_assert=>assert_equals( act = v exp = `it's` ).
+  ENDMETHOD.
+  METHOD double_escapes.
+    lcl_parser=>resolve_scalar( EXPORTING raw = `"a\tb"` IMPORTING value = DATA(v) is_null = DATA(n) ).
+    cl_abap_unit_assert=>assert_equals( act = v exp = |a\tb| ).
+  ENDMETHOD.
+  METHOD tilde_is_null.
+    lcl_parser=>resolve_scalar( EXPORTING raw = `~` IMPORTING value = DATA(v) is_null = DATA(n) ).
+    cl_abap_unit_assert=>assert_equals( act = n exp = abap_true ).
+  ENDMETHOD.
+  METHOD flow_map.
+    DATA(r) = lcl_parser=>parse_flow( `{a: 1, b: 2}` ).
+    cl_abap_unit_assert=>assert_equals( act = r->node-kind exp = c_node=>mapping ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-key exp = `b` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = `2` ).
+  ENDMETHOD.
+  METHOD flow_seq.
+    DATA(r) = lcl_parser=>parse_flow( `[x, y, z]` ).
+    cl_abap_unit_assert=>assert_equals( act = r->node-kind exp = c_node=>sequence ).
+    cl_abap_unit_assert=>assert_equals( act = lines( r->children ) exp = 3 ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 3 ]-node->node-value exp = `z` ).
+  ENDMETHOD.
+  METHOD colon_in_quotes.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |a: "x: y"| ) ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `x: y` ).
+  ENDMETHOD.
+  METHOD unterminated_fails.
+    TRY.
+        lcl_parser=>resolve_scalar( EXPORTING raw = `"oops` IMPORTING value = DATA(v) is_null = DATA(n) ).
+        cl_abap_unit_assert=>fail( `expected unterminated` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.
+
 CLASS ltc_parser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
     METHODS flat_mapping       FOR TESTING RAISING cx_sy_conversion_error.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -260,3 +260,53 @@ CLASS ltc_block_scalar IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = v( |k: \|+\n  line1\n| ) exp = |line1\n\n| ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_deser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS flat_struct        FOR TESTING.
+    METHODS nested_struct      FOR TESTING.
+    METHODS table_of_struct    FOR TESTING.
+    METHODS strict_bad_number  FOR TESTING.
+    METHODS lenient_bad_number FOR TESTING.
+ENDCLASS.
+CLASS ltc_deser IMPLEMENTATION.
+  METHOD flat_struct.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |name: web\nport: 8080| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-name exp = `web` ).
+    cl_abap_unit_assert=>assert_equals( act = out-port exp = 8080 ).
+  ENDMETHOD.
+  METHOD nested_struct.
+    TYPES: BEGIN OF ty_i, host TYPE string, port TYPE i, END OF ty_i.
+    TYPES: BEGIN OF ty, name TYPE string, inner TYPE ty_i, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |name: x\ninner:\n  host: h\n  port: 5| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-inner-host exp = `h` ).
+    cl_abap_unit_assert=>assert_equals( act = out-inner-port exp = 5 ).
+  ENDMETHOD.
+  METHOD table_of_struct.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA out TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |- name: a\n  port: 1\n- name: b\n  port: 2| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = lines( out ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = out[ 2 ]-port exp = 2 ).
+  ENDMETHOD.
+  METHOD strict_bad_number.
+    TYPES: BEGIN OF ty, port TYPE i, END OF ty.
+    DATA out TYPE ty.
+    DATA(o) = NEW z_ui2_yaml( strict_mode = abap_true ).
+    TRY.
+        o->deserialize_int( EXPORTING yaml = |port: notanumber| CHANGING data = out ).
+        cl_abap_unit_assert=>fail( `expected cast error` ).
+      CATCH cx_sy_move_cast_error.
+    ENDTRY.
+  ENDMETHOD.
+  METHOD lenient_bad_number.
+    TYPES: BEGIN OF ty, port TYPE i, END OF ty.
+    DATA out TYPE ty.
+    " lenient (static): bad number left initial, no raise
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |port: notanumber| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-port exp = 0 ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -70,12 +70,13 @@ ENDCLASS.
 
 CLASS ltc_parser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
-    METHODS flat_mapping     FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS nested_mapping   FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS block_sequence   FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS seq_of_mappings  FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS key_null_value   FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS bad_dedent_fails FOR TESTING.
+    METHODS flat_mapping       FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS nested_mapping     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS block_sequence     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS seq_of_mappings    FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS key_null_value     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS bad_dedent_fails   FOR TESTING.
+    METHODS scalar_with_colon  FOR TESTING RAISING cx_sy_conversion_error.
     METHODS p IMPORTING t TYPE string RETURNING VALUE(r) TYPE ty_node_ref RAISING cx_sy_conversion_error.
 ENDCLASS.
 CLASS ltc_parser IMPLEMENTATION.
@@ -121,5 +122,12 @@ CLASS ltc_parser IMPLEMENTATION.
         cl_abap_unit_assert=>fail( `expected bad dedent` ).
       CATCH cx_sy_conversion_error.
     ENDTRY.
+  ENDMETHOD.
+  METHOD scalar_with_colon.
+    " a sequence item that is a URL must stay a scalar, not become a mapping
+    DATA(r) = p( |- http://example.com\n- plain| ).
+    cl_abap_unit_assert=>assert_equals( act = r->node-kind exp = c_node=>sequence ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-kind exp = c_node=>scalar ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `http://example.com` ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -310,3 +310,39 @@ CLASS ltc_deser IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = out-port exp = 0 ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_gen DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS gen_mapping_field FOR TESTING.
+    METHODS gen_typed_int     FOR TESTING.
+    METHODS gen_string_field  FOR TESTING.
+    METHODS gen_sequence      FOR TESTING.
+ENDCLASS.
+CLASS ltc_gen IMPLEMENTATION.
+  METHOD gen_mapping_field.
+    DATA(r) = z_ui2_yaml=>generate( |host: localhost\nport: 5432| ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN r->* TO <s>.
+    FIELD-SYMBOLS <f> TYPE any. ASSIGN COMPONENT `HOST` OF STRUCTURE <s> TO <f>.
+    cl_abap_unit_assert=>assert_subrc( ).
+    cl_abap_unit_assert=>assert_equals( act = <f> exp = `localhost` ).
+  ENDMETHOD.
+  METHOD gen_typed_int.
+    DATA(r) = z_ui2_yaml=>generate( |port: 5432| ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN r->* TO <s>.
+    FIELD-SYMBOLS <f> TYPE any. ASSIGN COMPONENT `PORT` OF STRUCTURE <s> TO <f>.
+    DATA(td) = cl_abap_typedescr=>describe_by_data( <f> ).
+    cl_abap_unit_assert=>assert_differs( act = td->type_kind exp = cl_abap_typedescr=>typekind_string ).
+    cl_abap_unit_assert=>assert_equals( act = <f> exp = 5432 ).
+  ENDMETHOD.
+  METHOD gen_string_field.
+    DATA(r) = z_ui2_yaml=>generate( |name: web-01| ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN r->* TO <s>.
+    FIELD-SYMBOLS <f> TYPE any. ASSIGN COMPONENT `NAME` OF STRUCTURE <s> TO <f>.
+    cl_abap_unit_assert=>assert_equals( act = <f> exp = `web-01` ).
+  ENDMETHOD.
+  METHOD gen_sequence.
+    DATA(r) = z_ui2_yaml=>generate( |- 1\n- 2\n- 3| ).
+    FIELD-SYMBOLS <t> TYPE ANY TABLE. ASSIGN r->* TO <t>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <t> ) exp = 3 ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -367,7 +367,8 @@ CLASS ltc_ser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS quotes_colon             FOR TESTING.
     METHODS quotes_numeric_string    FOR TESTING.
     METHODS table_seq                FOR TESTING.
-    METHODS bool_emits_true_false        FOR TESTING.
+    METHODS bool_emits_true_false    FOR TESTING.
+    METHODS bool_round_trip          FOR TESTING.
     METHODS round_trip               FOR TESTING.
 ENDCLASS.
 CLASS ltc_ser IMPLEMENTATION.
@@ -401,11 +402,44 @@ CLASS ltc_ser IMPLEMENTATION.
     DATA(in) = VALUE ty( enabled = abap_true disabled = abap_false ).
     cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>serialize( in ) exp = |ENABLED: true\nDISABLED: false| ).
   ENDMETHOD.
+  METHOD bool_round_trip.
+    TYPES: BEGIN OF ty, enabled TYPE abap_bool, disabled TYPE abap_bool, END OF ty.
+    DATA(in) = VALUE ty( enabled = abap_true disabled = abap_false ).
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = z_ui2_yaml=>serialize( in ) CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-enabled exp = abap_true ).
+    cl_abap_unit_assert=>assert_equals( act = out-disabled exp = abap_false ).
+  ENDMETHOD.
   METHOD round_trip.
     TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
     DATA(in) = VALUE ty( name = `a: b` port = 7 ).
     DATA out TYPE ty.
     z_ui2_yaml=>deserialize( EXPORTING yaml = z_ui2_yaml=>serialize( in ) CHANGING data = out ).
     cl_abap_unit_assert=>assert_equals( act = out exp = in ).
+  ENDMETHOD.
+ENDCLASS.
+
+CLASS ltc_fixtures DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS servers_list FOR TESTING.
+    METHODS app_config   FOR TESTING.
+ENDCLASS.
+CLASS ltc_fixtures IMPLEMENTATION.
+  METHOD servers_list.
+    TYPES: BEGIN OF ty_s, host TYPE string, port TYPE i, END OF ty_s.
+    TYPES: BEGIN OF ty_w, servers TYPE STANDARD TABLE OF ty_s WITH DEFAULT KEY, END OF ty_w.
+    DATA w TYPE ty_w.
+    DATA(yaml) = |servers:\n  - host: a\n    port: 1\n  - host: b\n    port: 2|.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = yaml CHANGING data = w ).
+    cl_abap_unit_assert=>assert_equals( act = lines( w-servers ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = w-servers[ 2 ]-host exp = `b` ).
+  ENDMETHOD.
+  METHOD app_config.
+    TYPES: BEGIN OF ty, name TYPE string, enabled TYPE abap_bool, replicas TYPE i, END OF ty.
+    DATA cfg TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |name: web\nenabled: true\nreplicas: 3| CHANGING data = cfg ).
+    cl_abap_unit_assert=>assert_equals( act = cfg-name exp = `web` ).
+    cl_abap_unit_assert=>assert_equals( act = cfg-enabled exp = abap_true ).
+    cl_abap_unit_assert=>assert_equals( act = cfg-replicas exp = 3 ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -367,6 +367,7 @@ CLASS ltc_gen DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS gen_dup_sanitized_keys      FOR TESTING.
     METHODS gen_structural_error_fatal  FOR TESTING.
     METHODS gen_nonuniform_seq_keeps_all FOR TESTING.
+    METHODS gen_mixed_elem_keeps_values FOR TESTING.
 ENDCLASS.
 CLASS ltc_gen IMPLEMENTATION.
   METHOD gen_mapping_field.
@@ -421,6 +422,15 @@ CLASS ltc_gen IMPLEMENTATION.
     FIELD-SYMBOLS <t> TYPE ANY TABLE.
     ASSIGN r->* TO <t>.
     cl_abap_unit_assert=>assert_equals( act = lines( <t> ) exp = 4 ).
+  ENDMETHOD.
+  METHOD gen_mixed_elem_keeps_values.
+    " mixed elementary types (int + decimal + int) → string-table fallback preserves all values
+    " Under kind-only uniformity check this was TABLE OF I and truncated 2.5 → 2
+    DATA(r) = z_ui2_yaml=>generate( |- 1\n- 2.5\n- 3| ).
+    FIELD-SYMBOLS <t> TYPE STANDARD TABLE. ASSIGN r->* TO <t>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <t> ) exp = 3 ).
+    FIELD-SYMBOLS <e> TYPE any. READ TABLE <t> INDEX 2 ASSIGNING <e>.
+    cl_abap_unit_assert=>assert_char_cp( act = |{ <e> }| exp = `*2.5*` ).
   ENDMETHOD.
 ENDCLASS.
 

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -380,6 +380,8 @@ CLASS ltc_gen DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS gen_structural_error_fatal  FOR TESTING.
     METHODS gen_nonuniform_seq_keeps_all FOR TESTING.
     METHODS gen_mixed_elem_keeps_values FOR TESTING.
+    METHODS gen_seq_of_mappings         FOR TESTING.
+    METHODS gen_seq_of_mappings_typed   FOR TESTING.
 ENDCLASS.
 CLASS ltc_gen IMPLEMENTATION.
   METHOD gen_mapping_field.
@@ -443,6 +445,20 @@ CLASS ltc_gen IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = lines( <t> ) exp = 3 ).
     FIELD-SYMBOLS <e> TYPE any. READ TABLE <t> INDEX 2 ASSIGNING <e>.
     cl_abap_unit_assert=>assert_char_cp( act = |{ <e> }| exp = `*2.5*` ).
+  ENDMETHOD.
+  METHOD gen_seq_of_mappings.
+    " list of uniform objects (dominant config shape) must generate a table of 3, no dump
+    DATA(r) = z_ui2_yaml=>generate( |- host: a\n  port: 1\n- host: b\n  port: 2\n- host: c\n  port: 3| ).
+    FIELD-SYMBOLS <t> TYPE ANY TABLE. ASSIGN r->* TO <t>.
+    cl_abap_unit_assert=>assert_equals( act = lines( <t> ) exp = 3 ).
+  ENDMETHOD.
+  METHOD gen_seq_of_mappings_typed.
+    " values inside the objects survive: read row 2's host + port
+    DATA(r) = z_ui2_yaml=>generate( |- host: a\n  port: 1\n- host: b\n  port: 2| ).
+    FIELD-SYMBOLS <t> TYPE STANDARD TABLE. ASSIGN r->* TO <t>.
+    FIELD-SYMBOLS <row> TYPE any. READ TABLE <t> INDEX 2 ASSIGNING <row>.
+    FIELD-SYMBOLS <h> TYPE any. ASSIGN COMPONENT `HOST` OF STRUCTURE <row> TO <h>.
+    cl_abap_unit_assert=>assert_equals( act = <h> exp = `b` ).
   ENDMETHOD.
 ENDCLASS.
 

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -67,3 +67,59 @@ CLASS ltc_tree IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = s->node-is_null exp = abap_false ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_parser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS flat_mapping     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS nested_mapping   FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS block_sequence   FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS seq_of_mappings  FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS key_null_value   FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS bad_dedent_fails FOR TESTING.
+    METHODS p IMPORTING t TYPE string RETURNING VALUE(r) TYPE ty_node_ref RAISING cx_sy_conversion_error.
+ENDCLASS.
+CLASS ltc_parser IMPLEMENTATION.
+  METHOD p.
+    r = lcl_parser=>parse( lcl_scanner=>scan( t ) ).
+  ENDMETHOD.
+  METHOD flat_mapping.
+    DATA(r) = p( |a: 1\nb: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = r->node-kind exp = c_node=>mapping ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-key exp = `a` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `1` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = `2` ).
+  ENDMETHOD.
+  METHOD nested_mapping.
+    DATA(r) = p( |parent:\n  child: v| ).
+    DATA(pn) = r->children[ 1 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = pn->node-kind exp = c_node=>mapping ).
+    cl_abap_unit_assert=>assert_equals( act = pn->children[ 1 ]-key exp = `child` ).
+    cl_abap_unit_assert=>assert_equals( act = pn->children[ 1 ]-node->node-value exp = `v` ).
+  ENDMETHOD.
+  METHOD block_sequence.
+    DATA(r) = p( |- x\n- y| ).
+    cl_abap_unit_assert=>assert_equals( act = r->node-kind exp = c_node=>sequence ).
+    cl_abap_unit_assert=>assert_equals( act = lines( r->children ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = `y` ).
+  ENDMETHOD.
+  METHOD seq_of_mappings.
+    DATA(r) = p( |- name: a\n  port: 1\n- name: b\n  port: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = lines( r->children ) exp = 2 ).
+    DATA(first) = r->children[ 1 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = first->node-kind exp = c_node=>mapping ).
+    cl_abap_unit_assert=>assert_equals( act = first->children[ 1 ]-node->node-value exp = `a` ).
+    cl_abap_unit_assert=>assert_equals( act = first->children[ 2 ]-key exp = `port` ).
+  ENDMETHOD.
+  METHOD key_null_value.
+    DATA(r) = p( |a:\nb: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-is_null exp = abap_true ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = `2` ).
+  ENDMETHOD.
+  METHOD bad_dedent_fails.
+    TRY.
+        lcl_parser=>parse( lcl_scanner=>scan( |a:\n    b: 1\n   c: 2| ) ).
+        cl_abap_unit_assert=>fail( `expected bad dedent` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -367,6 +367,7 @@ CLASS ltc_ser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS quotes_colon             FOR TESTING.
     METHODS quotes_numeric_string    FOR TESTING.
     METHODS table_seq                FOR TESTING.
+    METHODS bool_emits_true_false        FOR TESTING.
     METHODS round_trip               FOR TESTING.
 ENDCLASS.
 CLASS ltc_ser IMPLEMENTATION.
@@ -394,6 +395,11 @@ CLASS ltc_ser IMPLEMENTATION.
     z_ui2_yaml=>deserialize( EXPORTING yaml = y CHANGING data = out ).
     cl_abap_unit_assert=>assert_equals( act = lines( out ) exp = 2 ).
     cl_abap_unit_assert=>assert_equals( act = out[ 2 ]-name exp = `b` ).
+  ENDMETHOD.
+  METHOD bool_emits_true_false.
+    TYPES: BEGIN OF ty, enabled TYPE abap_bool, disabled TYPE abap_bool, END OF ty.
+    DATA(in) = VALUE ty( enabled = abap_true disabled = abap_false ).
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>serialize( in ) exp = |ENABLED: true\nDISABLED: false| ).
   ENDMETHOD.
   METHOD round_trip.
     TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -313,10 +313,11 @@ ENDCLASS.
 
 CLASS ltc_gen DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
-    METHODS gen_mapping_field FOR TESTING.
-    METHODS gen_typed_int     FOR TESTING.
-    METHODS gen_string_field  FOR TESTING.
-    METHODS gen_sequence      FOR TESTING.
+    METHODS gen_mapping_field       FOR TESTING.
+    METHODS gen_typed_int           FOR TESTING.
+    METHODS gen_string_field        FOR TESTING.
+    METHODS gen_sequence            FOR TESTING.
+    METHODS gen_dup_sanitized_keys  FOR TESTING.
 ENDCLASS.
 CLASS ltc_gen IMPLEMENTATION.
   METHOD gen_mapping_field.
@@ -344,5 +345,18 @@ CLASS ltc_gen IMPLEMENTATION.
     DATA(r) = z_ui2_yaml=>generate( |- 1\n- 2\n- 3| ).
     FIELD-SYMBOLS <t> TYPE ANY TABLE. ASSIGN r->* TO <t>.
     cl_abap_unit_assert=>assert_equals( act = lines( <t> ) exp = 3 ).
+    " element type must be typed (not string) — integers 1/2/3 → TYPE i
+    FIELD-SYMBOLS <st> TYPE STANDARD TABLE. ASSIGN r->* TO <st>.
+    FIELD-SYMBOLS <e> TYPE any. READ TABLE <st> INDEX 1 ASSIGNING <e>.
+    DATA(etd) = cl_abap_typedescr=>describe_by_data( <e> ).
+    cl_abap_unit_assert=>assert_differs( act = etd->type_kind exp = cl_abap_typedescr=>typekind_string ).
+  ENDMETHOD.
+  METHOD gen_dup_sanitized_keys.
+    " my-key and my_key both sanitize to MY_KEY — must not dump, must produce 2 distinct components
+    DATA(r) = z_ui2_yaml=>generate( |my-key: 1\nmy_key: 2| ).
+    cl_abap_unit_assert=>assert_bound( r ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN r->* TO <s>.
+    DATA(td) = CAST cl_abap_structdescr( cl_abap_typedescr=>describe_by_data( <s> ) ).
+    cl_abap_unit_assert=>assert_equals( act = lines( td->components ) exp = 2 ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -47,3 +47,23 @@ CLASS ltc_scanner IMPLEMENTATION.
     ENDTRY.
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_tree DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS build_mapping FOR TESTING.
+ENDCLASS.
+CLASS ltc_tree IMPLEMENTATION.
+  METHOD build_mapping.
+    DATA(m) = lcl_tree=>new_collection( c_node=>mapping ).
+    lcl_tree=>add_child( node = m key = `a` child = lcl_tree=>new_scalar( `1` ) ).
+    lcl_tree=>add_child( node = m key = `b` child = lcl_tree=>new_scalar( `2` ) ).
+    cl_abap_unit_assert=>assert_equals( act = m->node-kind exp = c_node=>mapping ).
+    cl_abap_unit_assert=>assert_equals( act = lines( m->children ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = m->children[ 1 ]-key exp = `a` ).
+    cl_abap_unit_assert=>assert_equals( act = m->children[ 1 ]-node->node-value exp = `1` ).
+    cl_abap_unit_assert=>assert_equals( act = m->children[ 2 ]-node->node-value exp = `2` ).
+    " a scalar built with default is_null must be false
+    DATA(s) = lcl_tree=>new_scalar( `x` ).
+    cl_abap_unit_assert=>assert_equals( act = s->node-is_null exp = abap_false ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -507,3 +507,39 @@ CLASS ltc_fixtures IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = w-servers[ 2 ]-host exp = `b` ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_multidoc DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS generate_all_three    FOR TESTING.
+    METHODS deserialize_all_typed FOR TESTING.
+    METHODS single_doc_degenerate FOR TESTING.
+    METHODS legacy_first_doc_only FOR TESTING.
+ENDCLASS.
+CLASS ltc_multidoc IMPLEMENTATION.
+  METHOD generate_all_three.
+    DATA(rt) = z_ui2_yaml=>generate_all( |a: 1\n---\na: 2\n---\na: 3| ).
+    cl_abap_unit_assert=>assert_equals( act = lines( rt ) exp = 3 ).
+    FIELD-SYMBOLS <s> TYPE any. ASSIGN rt[ 2 ]->* TO <s>.
+    FIELD-SYMBOLS <f> TYPE any. ASSIGN COMPONENT `A` OF STRUCTURE <s> TO <f>.
+    cl_abap_unit_assert=>assert_equals( act = <f> exp = 2 ).
+  ENDMETHOD.
+  METHOD deserialize_all_typed.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA results TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    z_ui2_yaml=>deserialize_all( EXPORTING yaml = |name: a\nport: 1\n---\nname: b\nport: 2|
+                                 CHANGING  results = results ).
+    cl_abap_unit_assert=>assert_equals( act = lines( results ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = results[ 2 ]-name exp = `b` ).
+    cl_abap_unit_assert=>assert_equals( act = results[ 2 ]-port exp = 2 ).
+  ENDMETHOD.
+  METHOD single_doc_degenerate.
+    DATA(rt) = z_ui2_yaml=>generate_all( |a: 1| ).
+    cl_abap_unit_assert=>assert_equals( act = lines( rt ) exp = 1 ).
+  ENDMETHOD.
+  METHOD legacy_first_doc_only.
+    TYPES: BEGIN OF ty, a TYPE i, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a: 1\n---\na: 2| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-a exp = 1 ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -79,6 +79,7 @@ CLASS ltc_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS unterminated_fails FOR TESTING.
     METHODS flow_map_varlen    FOR TESTING RAISING cx_sy_conversion_error.
     METHODS flow_nested        FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS hash_in_quotes     FOR TESTING RAISING cx_sy_conversion_error.
 ENDCLASS.
 CLASS ltc_scalar IMPLEMENTATION.
   METHOD single_quote.
@@ -130,17 +131,22 @@ CLASS ltc_scalar IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = lines( av->children ) exp = 2 ).
     cl_abap_unit_assert=>assert_equals( act = av->children[ 2 ]-node->node-value exp = `2` ).
   ENDMETHOD.
+  METHOD hash_in_quotes.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |msg: "hello # world"| ) ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `hello # world` ).
+  ENDMETHOD.
 ENDCLASS.
 
 CLASS ltc_parser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
-    METHODS flat_mapping       FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS nested_mapping     FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS block_sequence     FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS seq_of_mappings    FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS key_null_value     FOR TESTING RAISING cx_sy_conversion_error.
-    METHODS bad_dedent_fails   FOR TESTING.
-    METHODS scalar_with_colon  FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS flat_mapping          FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS nested_mapping        FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS block_sequence        FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS seq_of_mappings       FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS key_null_value        FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS bad_dedent_fails      FOR TESTING.
+    METHODS scalar_with_colon     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS flush_seq_under_key   FOR TESTING RAISING cx_sy_conversion_error.
     METHODS p IMPORTING t TYPE string RETURNING VALUE(r) TYPE ty_node_ref RAISING cx_sy_conversion_error.
 ENDCLASS.
 CLASS ltc_parser IMPLEMENTATION.
@@ -193,6 +199,14 @@ CLASS ltc_parser IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = r->node-kind exp = c_node=>sequence ).
     cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-kind exp = c_node=>scalar ).
     cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `http://example.com` ).
+  ENDMETHOD.
+  METHOD flush_seq_under_key.
+    " flush style: sequence items at SAME indent as the key
+    DATA(r) = p( |servers:\n- host: a\n  port: 1\n- host: b\n  port: 2| ).
+    DATA(servers) = r->children[ 1 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = servers->node-kind exp = c_node=>sequence ).
+    cl_abap_unit_assert=>assert_equals( act = lines( servers->children ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = servers->children[ 2 ]-node->children[ 1 ]-node->node-value exp = `b` ).
   ENDMETHOD.
 ENDCLASS.
 
@@ -313,11 +327,12 @@ ENDCLASS.
 
 CLASS ltc_gen DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
-    METHODS gen_mapping_field       FOR TESTING.
-    METHODS gen_typed_int           FOR TESTING.
-    METHODS gen_string_field        FOR TESTING.
-    METHODS gen_sequence            FOR TESTING.
-    METHODS gen_dup_sanitized_keys  FOR TESTING.
+    METHODS gen_mapping_field           FOR TESTING.
+    METHODS gen_typed_int               FOR TESTING.
+    METHODS gen_string_field            FOR TESTING.
+    METHODS gen_sequence                FOR TESTING.
+    METHODS gen_dup_sanitized_keys      FOR TESTING.
+    METHODS gen_structural_error_fatal  FOR TESTING.
 ENDCLASS.
 CLASS ltc_gen IMPLEMENTATION.
   METHOD gen_mapping_field.
@@ -358,6 +373,13 @@ CLASS ltc_gen IMPLEMENTATION.
     FIELD-SYMBOLS <s> TYPE any. ASSIGN r->* TO <s>.
     DATA(td) = CAST cl_abap_structdescr( cl_abap_typedescr=>describe_by_data( <s> ) ).
     cl_abap_unit_assert=>assert_equals( act = lines( td->components ) exp = 2 ).
+  ENDMETHOD.
+  METHOD gen_structural_error_fatal.
+    TRY.
+        DATA(r) = z_ui2_yaml=>generate( |a:\n\tb: 1| ).  " tab in indentation = structural error
+        cl_abap_unit_assert=>fail( `expected structural error to propagate` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
   ENDMETHOD.
 ENDCLASS.
 
@@ -421,8 +443,9 @@ ENDCLASS.
 
 CLASS ltc_fixtures DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
-    METHODS servers_list FOR TESTING.
-    METHODS app_config   FOR TESTING.
+    METHODS servers_list        FOR TESTING.
+    METHODS app_config          FOR TESTING.
+    METHODS flush_servers_typed FOR TESTING.
 ENDCLASS.
 CLASS ltc_fixtures IMPLEMENTATION.
   METHOD servers_list.
@@ -441,5 +464,13 @@ CLASS ltc_fixtures IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = cfg-name exp = `web` ).
     cl_abap_unit_assert=>assert_equals( act = cfg-enabled exp = abap_true ).
     cl_abap_unit_assert=>assert_equals( act = cfg-replicas exp = 3 ).
+  ENDMETHOD.
+  METHOD flush_servers_typed.
+    TYPES: BEGIN OF ty_s, host TYPE string, port TYPE i, END OF ty_s.
+    TYPES: BEGIN OF ty_w, servers TYPE STANDARD TABLE OF ty_s WITH DEFAULT KEY, END OF ty_w.
+    DATA w TYPE ty_w.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |servers:\n- host: a\n  port: 1\n- host: b\n  port: 2| CHANGING data = w ).
+    cl_abap_unit_assert=>assert_equals( act = lines( w-servers ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = w-servers[ 2 ]-host exp = `b` ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -196,6 +196,32 @@ CLASS ltc_parser IMPLEMENTATION.
   ENDMETHOD.
 ENDCLASS.
 
+CLASS ltc_anchor DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS scalar_alias          FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS mapping_alias         FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS undefined_alias_fails FOR TESTING.
+ENDCLASS.
+CLASS ltc_anchor IMPLEMENTATION.
+  METHOD scalar_alias.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |a: &v hello\nb: *v| ) ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `hello` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = `hello` ).
+  ENDMETHOD.
+  METHOD mapping_alias.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |base: &d\n  timeout: 30\nother: *d| ) ).
+    DATA(other) = r->children[ 2 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = other->node-kind exp = c_node=>mapping ).
+    cl_abap_unit_assert=>assert_equals( act = other->children[ 1 ]-node->node-value exp = `30` ).
+  ENDMETHOD.
+  METHOD undefined_alias_fails.
+    TRY.
+        lcl_parser=>parse( lcl_scanner=>scan( |a: *missing| ) ).
+        cl_abap_unit_assert=>fail( `expected undefined alias` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.
 CLASS ltc_block_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
     METHODS literal_keeps_newlines FOR TESTING RAISING cx_sy_conversion_error.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -260,6 +260,7 @@ CLASS ltc_block_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS
     METHODS folded_joins_lines     FOR TESTING RAISING cx_sy_conversion_error.
     METHODS strip_chomp            FOR TESTING RAISING cx_sy_conversion_error.
     METHODS keep_chomp             FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS crlf_block_scalar      FOR TESTING RAISING cx_sy_conversion_error.
     METHODS v IMPORTING t TYPE string RETURNING VALUE(r) TYPE string RAISING cx_sy_conversion_error.
 ENDCLASS.
 CLASS ltc_block_scalar IMPLEMENTATION.
@@ -279,6 +280,17 @@ CLASS ltc_block_scalar IMPLEMENTATION.
   METHOD keep_chomp.
     " |+ keeps trailing blank line -> "line1\n\n"
     cl_abap_unit_assert=>assert_equals( act = v( |k: \|+\n  line1\n| ) exp = |line1\n\n| ).
+  ENDMETHOD.
+  METHOD crlf_block_scalar.
+    " CRLF input: block-scalar body lines must have CR stripped, no early truncation
+    DATA(crlf) = cl_abap_char_utilities=>cr_lf.
+    DATA(y) = |k: \|{ crlf }  line1{ crlf }{ crlf }  line3{ crlf }next: x|.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( y ) ).
+    " literal block: line1 + blank line + line3 + clip newline
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value
+                                        exp = |line1\n\nline3\n| ).
+    " sibling key must be present (no early truncation)
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-key exp = `next` ).
   ENDMETHOD.
 ENDCLASS.
 

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -360,3 +360,46 @@ CLASS ltc_gen IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = lines( td->components ) exp = 2 ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_ser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS flat_struct              FOR TESTING.
+    METHODS quotes_colon             FOR TESTING.
+    METHODS quotes_numeric_string    FOR TESTING.
+    METHODS table_seq                FOR TESTING.
+    METHODS round_trip               FOR TESTING.
+ENDCLASS.
+CLASS ltc_ser IMPLEMENTATION.
+  METHOD flat_struct.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA(in) = VALUE ty( name = `web` port = 8080 ).
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>serialize( in ) exp = |NAME: web\nPORT: 8080| ).
+  ENDMETHOD.
+  METHOD quotes_colon.
+    TYPES: BEGIN OF ty, t TYPE string, END OF ty.
+    DATA(in) = VALUE ty( t = `x: y` ).
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>serialize( in ) exp = |T: "x: y"| ).
+  ENDMETHOD.
+  METHOD quotes_numeric_string.
+    TYPES: BEGIN OF ty, code TYPE string, END OF ty.
+    DATA(in) = VALUE ty( code = `007` ).
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>serialize( in ) exp = |CODE: "007"| ).
+  ENDMETHOD.
+  METHOD table_seq.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA tab TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    tab = VALUE #( ( name = `a` port = 1 ) ( name = `b` port = 2 ) ).
+    DATA(y) = z_ui2_yaml=>serialize( tab ).
+    DATA out TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = y CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = lines( out ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = out[ 2 ]-name exp = `b` ).
+  ENDMETHOD.
+  METHOD round_trip.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA(in) = VALUE ty( name = `a: b` port = 7 ).
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = z_ui2_yaml=>serialize( in ) CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out exp = in ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -201,6 +201,7 @@ CLASS ltc_anchor DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS scalar_alias          FOR TESTING RAISING cx_sy_conversion_error.
     METHODS mapping_alias         FOR TESTING RAISING cx_sy_conversion_error.
     METHODS undefined_alias_fails FOR TESTING.
+    METHODS glob_is_not_alias     FOR TESTING RAISING cx_sy_conversion_error.
 ENDCLASS.
 CLASS ltc_anchor IMPLEMENTATION.
   METHOD scalar_alias.
@@ -213,6 +214,8 @@ CLASS ltc_anchor IMPLEMENTATION.
     DATA(other) = r->children[ 2 ]-node.
     cl_abap_unit_assert=>assert_equals( act = other->node-kind exp = c_node=>mapping ).
     cl_abap_unit_assert=>assert_equals( act = other->children[ 1 ]-node->node-value exp = `30` ).
+    " shared-reference contract: both children must point to the same lcl_node_ref instance
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node exp = r->children[ 2 ]-node ).
   ENDMETHOD.
   METHOD undefined_alias_fails.
     TRY.
@@ -220,6 +223,14 @@ CLASS ltc_anchor IMPLEMENTATION.
         cl_abap_unit_assert=>fail( `expected undefined alias` ).
       CATCH cx_sy_conversion_error.
     ENDTRY.
+  ENDMETHOD.
+  METHOD glob_is_not_alias.
+    " a value starting with * that isn't a valid alias name stays a scalar
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |pattern: '*.txt'| ) ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `*.txt` ).
+    " unquoted bare-ish glob also must not raise as an undefined alias
+    DATA(r2) = lcl_parser=>parse( lcl_scanner=>scan( |g: *.log| ) ).
+    cl_abap_unit_assert=>assert_equals( act = r2->children[ 1 ]-node->node-value exp = `*.log` ).
   ENDMETHOD.
 ENDCLASS.
 CLASS ltc_block_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -77,6 +77,8 @@ CLASS ltc_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS flow_seq           FOR TESTING RAISING cx_sy_conversion_error.
     METHODS colon_in_quotes    FOR TESTING RAISING cx_sy_conversion_error.
     METHODS unterminated_fails FOR TESTING.
+    METHODS flow_map_varlen    FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS flow_nested        FOR TESTING RAISING cx_sy_conversion_error.
 ENDCLASS.
 CLASS ltc_scalar IMPLEMENTATION.
   METHOD single_quote.
@@ -113,6 +115,20 @@ CLASS ltc_scalar IMPLEMENTATION.
         cl_abap_unit_assert=>fail( `expected unterminated` ).
       CATCH cx_sy_conversion_error.
     ENDTRY.
+  ENDMETHOD.
+  METHOD flow_map_varlen.
+    DATA(r) = lcl_parser=>parse_flow( `{abc: 1, b: 2}` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-key exp = `abc` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = `1` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-key exp = `b` ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = `2` ).
+  ENDMETHOD.
+  METHOD flow_nested.
+    DATA(r) = lcl_parser=>parse_flow( `{a: [1, 2]}` ).
+    DATA(av) = r->children[ 1 ]-node.
+    cl_abap_unit_assert=>assert_equals( act = av->node-kind exp = c_node=>sequence ).
+    cl_abap_unit_assert=>assert_equals( act = lines( av->children ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = av->children[ 2 ]-node->node-value exp = `2` ).
   ENDMETHOD.
 ENDCLASS.
 

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -216,6 +216,7 @@ CLASS ltc_anchor DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
     METHODS mapping_alias         FOR TESTING RAISING cx_sy_conversion_error.
     METHODS undefined_alias_fails FOR TESTING.
     METHODS glob_is_not_alias     FOR TESTING RAISING cx_sy_conversion_error.
+    METHODS block_header_anchor   FOR TESTING RAISING cx_sy_conversion_error.
 ENDCLASS.
 CLASS ltc_anchor IMPLEMENTATION.
   METHOD scalar_alias.
@@ -245,6 +246,12 @@ CLASS ltc_anchor IMPLEMENTATION.
     " unquoted bare-ish glob also must not raise as an undefined alias
     DATA(r2) = lcl_parser=>parse( lcl_scanner=>scan( |g: *.log| ) ).
     cl_abap_unit_assert=>assert_equals( act = r2->children[ 1 ]-node->node-value exp = `*.log` ).
+  ENDMETHOD.
+  METHOD block_header_anchor.
+    DATA(r) = lcl_parser=>parse( lcl_scanner=>scan( |a: &blk \|\n  line1\n  line2\nb: *blk| ) ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node->node-value exp = |line1\nline2\n| ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 2 ]-node->node-value exp = |line1\nline2\n| ).
+    cl_abap_unit_assert=>assert_equals( act = r->children[ 1 ]-node exp = r->children[ 2 ]-node ).
   ENDMETHOD.
 ENDCLASS.
 CLASS ltc_block_scalar DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -543,3 +543,122 @@ CLASS ltc_multidoc IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = out-a exp = 1 ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_phaseb DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    " C1 — static DESERIALIZE must not dump on structural errors
+    METHODS c1_tab_indent_lenient     FOR TESTING.
+    METHODS c1_bad_dedent_lenient     FOR TESTING.
+    METHODS c1_unterminated_lenient   FOR TESTING.
+    " C2 — CRLF input
+    METHODS c2_crlf_numeric           FOR TESTING.
+    METHODS c2_crlf_string            FOR TESTING.
+    " C3 — negative packed decimal trailing sign
+    METHODS c3_negative_packed        FOR TESTING.
+    " C4 — null/Null/NULL keyword
+    METHODS c4_null_lower             FOR TESTING.
+    METHODS c4_null_mixed             FOR TESTING.
+    METHODS c4_null_upper             FOR TESTING.
+    METHODS c4_quoted_null_is_string  FOR TESTING.
+    " C5 — indent_step respected for multi-line table rows
+    METHODS c5_indent_step_roundtrip  FOR TESTING.
+ENDCLASS.
+
+CLASS ltc_phaseb IMPLEMENTATION.
+
+  METHOD c1_tab_indent_lenient.
+    TYPES: BEGIN OF ty, a TYPE string, b TYPE string, END OF ty.
+    DATA out TYPE ty.
+    " tab in indentation → structural error; static API must absorb it, not dump
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a: hello\n\tb: world| CHANGING data = out ).
+    " out-a stays initial because structural error aborted before any mapping
+    cl_abap_unit_assert=>assert_not_initial( act = abap_true ).  " reaching here = no dump = pass
+  ENDMETHOD.
+
+  METHOD c1_bad_dedent_lenient.
+    TYPES: BEGIN OF ty, a TYPE string, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a:\n    b: 1\n   c: 2| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_not_initial( act = abap_true ).  " no dump = pass
+  ENDMETHOD.
+
+  METHOD c1_unterminated_lenient.
+    TYPES: BEGIN OF ty, k TYPE string, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |k: "oops| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_not_initial( act = abap_true ).  " no dump = pass
+  ENDMETHOD.
+
+  METHOD c2_crlf_numeric.
+    TYPES: BEGIN OF ty, port TYPE i, name TYPE string, END OF ty.
+    DATA out TYPE ty.
+    DATA(crlf) = cl_abap_char_utilities=>cr_lf.
+    DATA(yaml) = |port: 8080| && crlf && |name: web|.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = yaml CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-port exp = 8080 ).
+  ENDMETHOD.
+
+  METHOD c2_crlf_string.
+    TYPES: BEGIN OF ty, port TYPE i, name TYPE string, END OF ty.
+    DATA out TYPE ty.
+    DATA(crlf) = cl_abap_char_utilities=>cr_lf.
+    DATA(yaml) = |port: 8080| && crlf && |name: web|.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = yaml CHANGING data = out ).
+    " name must be exactly "web", no trailing CR
+    cl_abap_unit_assert=>assert_equals( act = out-name exp = `web` ).
+  ENDMETHOD.
+
+  METHOD c3_negative_packed.
+    TYPES: BEGIN OF ty, val TYPE p LENGTH 4 DECIMALS 2, END OF ty.
+    DATA(in) = VALUE ty( val = '-3.14' ).
+    DATA(yaml) = z_ui2_yaml=>serialize( in ).
+    " must contain "-3.14", not "3.14-"
+    cl_abap_unit_assert=>assert_char_cp( act = yaml exp = `*-3.14*` ).
+  ENDMETHOD.
+
+  METHOD c4_null_lower.
+    TYPES: BEGIN OF ty, a TYPE string, END OF ty.
+    DATA out TYPE ty.
+    out-a = `prior`.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a: null| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_initial( act = out-a ).
+  ENDMETHOD.
+
+  METHOD c4_null_mixed.
+    TYPES: BEGIN OF ty, a TYPE string, END OF ty.
+    DATA out TYPE ty.
+    out-a = `prior`.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a: Null| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_initial( act = out-a ).
+  ENDMETHOD.
+
+  METHOD c4_null_upper.
+    TYPES: BEGIN OF ty, a TYPE string, END OF ty.
+    DATA out TYPE ty.
+    out-a = `prior`.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a: NULL| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_initial( act = out-a ).
+  ENDMETHOD.
+
+  METHOD c4_quoted_null_is_string.
+    TYPES: BEGIN OF ty, a TYPE string, END OF ty.
+    DATA out TYPE ty.
+    z_ui2_yaml=>deserialize( EXPORTING yaml = |a: "null"| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-a exp = `null` ).
+  ENDMETHOD.
+
+  METHOD c5_indent_step_roundtrip.
+    TYPES: BEGIN OF ty, name TYPE string, port TYPE i, END OF ty.
+    DATA tab TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    tab = VALUE #( ( name = `a` port = 1 ) ( name = `b` port = 2 ) ).
+    DATA out TYPE STANDARD TABLE OF ty WITH DEFAULT KEY.
+    " indent=4: serialize then deserialize — round-trip must survive any indent width
+    DATA(o) = NEW z_ui2_yaml( indent = 4 ).
+    DATA(yaml) = o->serialize_int( tab ).
+    o->deserialize_int( EXPORTING yaml = yaml CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = lines( out ) exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = out[ 2 ]-name exp = `b` ).
+    cl_abap_unit_assert=>assert_equals( act = out[ 2 ]-port exp = 2 ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -1,0 +1,12 @@
+*"* use this source file for your ABAP unit test classes
+
+CLASS ltc_smoke DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS version_is_one FOR TESTING.
+ENDCLASS.
+
+CLASS ltc_smoke IMPLEMENTATION.
+  METHOD version_is_one.
+    cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>version exp = 1 ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -10,3 +10,40 @@ CLASS ltc_smoke IMPLEMENTATION.
     cl_abap_unit_assert=>assert_equals( act = z_ui2_yaml=>version exp = 1 ).
   ENDMETHOD.
 ENDCLASS.
+
+CLASS ltc_scanner DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS counts_indent          FOR TESTING.
+    METHODS strips_trailing_comment FOR TESTING.
+    METHODS keeps_hash_in_value    FOR TESTING.
+    METHODS drops_blank_and_comment FOR TESTING.
+    METHODS rejects_tab_indent     FOR TESTING.
+ENDCLASS.
+
+CLASS ltc_scanner IMPLEMENTATION.
+  METHOD counts_indent.
+    DATA(l) = lcl_scanner=>scan( |a: 1\n  b: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 1 ]-indent exp = 0 ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 2 ]-indent exp = 2 ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 2 ]-content exp = `b: 2` ).
+  ENDMETHOD.
+  METHOD strips_trailing_comment.
+    DATA(l) = lcl_scanner=>scan( |a: 1  # note| ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 1 ]-content exp = `a: 1` ).
+  ENDMETHOD.
+  METHOD keeps_hash_in_value.
+    DATA(l) = lcl_scanner=>scan( |a: v#alue| ).
+    cl_abap_unit_assert=>assert_equals( act = l[ 1 ]-content exp = `a: v#alue` ).
+  ENDMETHOD.
+  METHOD drops_blank_and_comment.
+    DATA(l) = lcl_scanner=>scan( |a: 1\n\n# just a comment\nb: 2| ).
+    cl_abap_unit_assert=>assert_equals( act = lines( l ) exp = 2 ).
+  ENDMETHOD.
+  METHOD rejects_tab_indent.
+    TRY.
+        lcl_scanner=>scan( |a:\n\tb: 2| ).
+        cl_abap_unit_assert=>fail( `expected tab rejection` ).
+      CATCH cx_sy_conversion_error.
+    ENDTRY.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml.clas.testclasses.abap
+++ b/src/z_ui2_yaml.clas.testclasses.abap
@@ -277,11 +277,14 @@ ENDCLASS.
 
 CLASS ltc_deser DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS.
   PRIVATE SECTION.
-    METHODS flat_struct        FOR TESTING.
-    METHODS nested_struct      FOR TESTING.
-    METHODS table_of_struct    FOR TESTING.
-    METHODS strict_bad_number  FOR TESTING.
-    METHODS lenient_bad_number FOR TESTING.
+    METHODS flat_struct          FOR TESTING.
+    METHODS nested_struct        FOR TESTING.
+    METHODS table_of_struct      FOR TESTING.
+    METHODS strict_bad_number    FOR TESTING.
+    METHODS lenient_bad_number   FOR TESTING.
+    METHODS camel_inverse_deser  FOR TESTING.
+    METHODS pascal_inverse_deser FOR TESTING.
+    METHODS camel_round_trip     FOR TESTING.
 ENDCLASS.
 CLASS ltc_deser IMPLEMENTATION.
   METHOD flat_struct.
@@ -322,6 +325,29 @@ CLASS ltc_deser IMPLEMENTATION.
     " lenient (static): bad number left initial, no raise
     z_ui2_yaml=>deserialize( EXPORTING yaml = |port: notanumber| CHANGING data = out ).
     cl_abap_unit_assert=>assert_equals( act = out-port exp = 0 ).
+  ENDMETHOD.
+  METHOD camel_inverse_deser.
+    TYPES: BEGIN OF ty, my_field TYPE string, another_one TYPE i, END OF ty.
+    DATA out TYPE ty.
+    DATA(o) = NEW z_ui2_yaml( pretty_name = z_ui2_yaml=>pretty_mode-camel_case ).
+    o->deserialize_int( EXPORTING yaml = |myField: hello\nanotherOne: 5| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-my_field exp = `hello` ).
+    cl_abap_unit_assert=>assert_equals( act = out-another_one exp = 5 ).
+  ENDMETHOD.
+  METHOD pascal_inverse_deser.
+    TYPES: BEGIN OF ty, my_field TYPE string, END OF ty.
+    DATA out TYPE ty.
+    DATA(o) = NEW z_ui2_yaml( pretty_name = z_ui2_yaml=>pretty_mode-pascal_case ).
+    o->deserialize_int( EXPORTING yaml = |MyField: hi| CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out-my_field exp = `hi` ).
+  ENDMETHOD.
+  METHOD camel_round_trip.
+    TYPES: BEGIN OF ty, my_field TYPE string, port_num TYPE i, END OF ty.
+    DATA(in) = VALUE ty( my_field = `x` port_num = 9 ).
+    DATA out TYPE ty.
+    DATA(o) = NEW z_ui2_yaml( pretty_name = z_ui2_yaml=>pretty_mode-camel_case ).
+    o->deserialize_int( EXPORTING yaml = o->serialize_int( in ) CHANGING data = out ).
+    cl_abap_unit_assert=>assert_equals( act = out exp = in ).
   ENDMETHOD.
 ENDCLASS.
 

--- a/src/z_ui2_yaml.clas.xml
+++ b/src/z_ui2_yaml.clas.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z_UI2_YAML</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>YAML 1.2 serializer/deserializer</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/z_ui2_yaml_perf.clas.abap
+++ b/src/z_ui2_yaml_perf.clas.abap
@@ -1,0 +1,131 @@
+CLASS z_ui2_yaml_perf DEFINITION
+  PUBLIC
+  FINAL
+  CREATE PUBLIC.
+
+  PUBLIC SECTION.
+
+    TYPES: BEGIN OF ty_runtime,
+             name       TYPE string,
+             usec       TYPE i,
+           END OF ty_runtime.
+
+    TYPES tt_runtime TYPE STANDARD TABLE OF ty_runtime WITH DEFAULT KEY.
+
+    CLASS-METHODS run
+      RETURNING VALUE(rt_result) TYPE tt_runtime.
+
+  PRIVATE SECTION.
+
+    CLASS-METHODS start_measurement
+      RETURNING VALUE(rv_start) TYPE i.
+
+    CLASS-METHODS end_measurement
+      IMPORTING iv_start           TYPE i
+      RETURNING VALUE(rv_duration) TYPE i.
+
+    CLASS-METHODS perf_serialize
+      RETURNING VALUE(rt_result) TYPE tt_runtime.
+
+    CLASS-METHODS perf_deserialize
+      RETURNING VALUE(rt_result) TYPE tt_runtime.
+
+    CLASS-METHODS perf_generate
+      RETURNING VALUE(rt_result) TYPE tt_runtime.
+
+ENDCLASS.
+
+
+CLASS z_ui2_yaml_perf IMPLEMENTATION.
+
+  METHOD run.
+    APPEND LINES OF perf_serialize( )   TO rt_result.
+    APPEND LINES OF perf_deserialize( ) TO rt_result.
+    APPEND LINES OF perf_generate( )    TO rt_result.
+  ENDMETHOD.
+
+  METHOD start_measurement.
+    GET RUN TIME FIELD rv_start.
+  ENDMETHOD.
+
+  METHOD end_measurement.
+    DATA(lv_now) = 0.
+    GET RUN TIME FIELD lv_now.
+    rv_duration = lv_now - iv_start.
+  ENDMETHOD.
+
+  METHOD perf_serialize.
+    TYPES: BEGIN OF ty_s, host TYPE string, port TYPE i, enabled TYPE abap_bool, END OF ty_s.
+    TYPES: BEGIN OF ty_w, name TYPE string, replicas TYPE i, servers TYPE STANDARD TABLE OF ty_s
+                                                              WITH DEFAULT KEY, END OF ty_w.
+
+    DATA(cfg) = VALUE ty_w(
+      name     = `production`
+      replicas = 3
+      servers  = VALUE #(
+        ( host = `db1.example.com` port = 5432 enabled = abap_true )
+        ( host = `db2.example.com` port = 5432 enabled = abap_true )
+        ( host = `db3.example.com` port = 5432 enabled = abap_false )
+      )
+    ).
+
+    DATA lv_start TYPE i.
+    DATA lv_total TYPE i.
+    DATA(lv_times) = 1000.
+
+    CLEAR lv_total.
+    DO lv_times TIMES.
+      lv_start = start_measurement( ).
+      DATA(lv_yaml) = z_ui2_yaml=>serialize( data = cfg pretty_name = z_ui2_yaml=>pretty_mode-low_case ).
+      lv_total += end_measurement( lv_start ).
+    ENDDO.
+    APPEND VALUE #( name = |Serialize small config ({ lv_times }x)| usec = lv_total / lv_times )
+           TO rt_result.
+  ENDMETHOD.
+
+  METHOD perf_deserialize.
+    DATA(lv_yaml) = |name: production\nreplicas: 3\nservers:\n|
+                 && |  - host: db1.example.com\n    port: 5432\n    enabled: true\n|
+                 && |  - host: db2.example.com\n    port: 5432\n    enabled: true\n|
+                 && |  - host: db3.example.com\n    port: 5432\n    enabled: false|.
+
+    TYPES: BEGIN OF ty_s, host TYPE string, port TYPE i, enabled TYPE abap_bool, END OF ty_s.
+    TYPES: BEGIN OF ty_w, name TYPE string, replicas TYPE i, servers TYPE STANDARD TABLE OF ty_s
+                                                              WITH DEFAULT KEY, END OF ty_w.
+    DATA lv_start TYPE i.
+    DATA lv_total TYPE i.
+    DATA(lv_times) = 1000.
+
+    CLEAR lv_total.
+    DO lv_times TIMES.
+      DATA cfg TYPE ty_w.
+      CLEAR cfg.
+      lv_start = start_measurement( ).
+      z_ui2_yaml=>deserialize( EXPORTING yaml = lv_yaml CHANGING data = cfg ).
+      lv_total += end_measurement( lv_start ).
+    ENDDO.
+    APPEND VALUE #( name = |Deserialize small config ({ lv_times }x)| usec = lv_total / lv_times )
+           TO rt_result.
+  ENDMETHOD.
+
+  METHOD perf_generate.
+    DATA(lv_yaml) = |name: production\nreplicas: 3\nservers:\n|
+                 && |  - host: db1.example.com\n    port: 5432\n|
+                 && |  - host: db2.example.com\n    port: 5432\n|
+                 && |  - host: db3.example.com\n    port: 5432|.
+
+    DATA lv_start TYPE i.
+    DATA lv_total TYPE i.
+    DATA(lv_times) = 1000.
+
+    CLEAR lv_total.
+    DO lv_times TIMES.
+      lv_start = start_measurement( ).
+      DATA(lv_ref) = z_ui2_yaml=>generate( lv_yaml ).
+      lv_total += end_measurement( lv_start ).
+    ENDDO.
+    APPEND VALUE #( name = |Generate small config ({ lv_times }x)| usec = lv_total / lv_times )
+           TO rt_result.
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/z_ui2_yaml_perf.clas.abap
+++ b/src/z_ui2_yaml_perf.clas.abap
@@ -33,15 +33,27 @@ CLASS z_ui2_yaml_perf DEFINITION
     CLASS-METHODS perf_generate
       RETURNING VALUE(rt_result) TYPE tt_runtime.
 
+    CLASS-METHODS perf_deserialize_large
+      RETURNING VALUE(rt_result) TYPE tt_runtime.
+
+    CLASS-METHODS perf_generate_large
+      RETURNING VALUE(rt_result) TYPE tt_runtime.
+
+    CLASS-METHODS build_large_yaml
+      IMPORTING iv_rows        TYPE i
+      RETURNING VALUE(rv_yaml) TYPE string.
+
 ENDCLASS.
 
 
 CLASS z_ui2_yaml_perf IMPLEMENTATION.
 
   METHOD run.
-    APPEND LINES OF perf_serialize( )   TO rt_result.
-    APPEND LINES OF perf_deserialize( ) TO rt_result.
-    APPEND LINES OF perf_generate( )    TO rt_result.
+    APPEND LINES OF perf_serialize( )         TO rt_result.
+    APPEND LINES OF perf_deserialize( )       TO rt_result.
+    APPEND LINES OF perf_generate( )          TO rt_result.
+    APPEND LINES OF perf_deserialize_large( ) TO rt_result.
+    APPEND LINES OF perf_generate_large( )    TO rt_result.
   ENDMETHOD.
 
   METHOD start_measurement.
@@ -125,6 +137,71 @@ CLASS z_ui2_yaml_perf IMPLEMENTATION.
       lv_total += end_measurement( lv_start ).
     ENDDO.
     APPEND VALUE #( name = |Generate small config ({ lv_times }x)| usec = lv_total / lv_times )
+           TO rt_result.
+  ENDMETHOD.
+
+  METHOD build_large_yaml.
+    " Build top-level sequence: rows of { host, port, enabled }.
+    " Uses string_table + CONCATENATE LINES OF for efficient O(n) construction.
+    DATA lt_lines TYPE string_table.
+    DO iv_rows TIMES.
+      APPEND |- host: h{ sy-index }| TO lt_lines.
+      APPEND |  port: 5432| TO lt_lines.
+      APPEND |  enabled: true| TO lt_lines.
+    ENDDO.
+    CONCATENATE LINES OF lt_lines INTO rv_yaml SEPARATED BY cl_abap_char_utilities=>newline.
+  ENDMETHOD.
+
+  METHOD perf_deserialize_large.
+    TYPES: BEGIN OF ty_s, host TYPE string, port TYPE i, enabled TYPE abap_bool, END OF ty_s.
+    DATA lt_out TYPE STANDARD TABLE OF ty_s WITH DEFAULT KEY.
+    DATA lv_start TYPE i.
+    DATA lv_total TYPE i.
+
+    " 10k rows, 3 iterations
+    DATA(lv_yaml_10k)  = build_large_yaml( 10000 ).
+    DATA(lv_iters_10k) = 3.
+    CLEAR lv_total.
+    DO lv_iters_10k TIMES.
+      CLEAR lt_out.
+      lv_start = start_measurement( ).
+      z_ui2_yaml=>deserialize( EXPORTING yaml = lv_yaml_10k CHANGING data = lt_out ).
+      lv_total += end_measurement( lv_start ).
+    ENDDO.
+    APPEND VALUE #( name = |Deserialize 10k rows ({ lv_iters_10k }x)| usec = lv_total / lv_iters_10k )
+           TO rt_result.
+
+    " 100k rows, 1 iteration (single-op wall-clock)
+    DATA(lv_yaml_100k) = build_large_yaml( 100000 ).
+    CLEAR lt_out.
+    lv_start = start_measurement( ).
+    z_ui2_yaml=>deserialize( EXPORTING yaml = lv_yaml_100k CHANGING data = lt_out ).
+    APPEND VALUE #( name = `Deserialize 100k rows (1x)` usec = end_measurement( lv_start ) )
+           TO rt_result.
+  ENDMETHOD.
+
+  METHOD perf_generate_large.
+    DATA lv_start TYPE i.
+    DATA lv_total TYPE i.
+    DATA lv_result TYPE REF TO data.
+
+    " 10k rows, 2 iterations
+    DATA(lv_yaml_10k)  = build_large_yaml( 10000 ).
+    DATA(lv_iters_10k) = 2.
+    CLEAR lv_total.
+    DO lv_iters_10k TIMES.
+      lv_start = start_measurement( ).
+      lv_result = z_ui2_yaml=>generate( lv_yaml_10k ).
+      lv_total += end_measurement( lv_start ).
+    ENDDO.
+    APPEND VALUE #( name = |Generate 10k rows ({ lv_iters_10k }x)| usec = lv_total / lv_iters_10k )
+           TO rt_result.
+
+    " 100k rows, 1 iteration
+    DATA(lv_yaml_100k) = build_large_yaml( 100000 ).
+    lv_start = start_measurement( ).
+    lv_result = z_ui2_yaml=>generate( lv_yaml_100k ).
+    APPEND VALUE #( name = `Generate 100k rows (1x)` usec = end_measurement( lv_start ) )
            TO rt_result.
   ENDMETHOD.
 

--- a/src/z_ui2_yaml_perf.clas.testclasses.abap
+++ b/src/z_ui2_yaml_perf.clas.testclasses.abap
@@ -1,0 +1,16 @@
+*"* use this source file for your ABAP unit test classes
+CLASS ltc_perf DEFINITION FOR TESTING DURATION LONG RISK LEVEL HARMLESS.
+  PRIVATE SECTION.
+    METHODS baseline FOR TESTING.
+ENDCLASS.
+CLASS ltc_perf IMPLEMENTATION.
+  METHOD baseline.
+    " Intentionally fails to expose baseline numbers — NOT a regression gate.
+    DATA(rt) = z_ui2_yaml_perf=>run( ).
+    DATA lv_msg TYPE string.
+    LOOP AT rt INTO DATA(row).
+      lv_msg = lv_msg && row-name && `: ` && row-usec && ` µs avg\n`.
+    ENDLOOP.
+    cl_abap_unit_assert=>fail( lv_msg ).
+  ENDMETHOD.
+ENDCLASS.

--- a/src/z_ui2_yaml_perf.clas.xml
+++ b/src/z_ui2_yaml_perf.clas.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>Z_UI2_YAML_PERF</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>YAML performance baseline harness</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
## Summary

New self-contained ABAP class `Z_UI2_YAML` — a YAML 1.2 serializer/deserializer for config files. Independent of `Z_UI2_JSON` (no shared code). SAP_BASIS 7.57+. **91 unit tests, all pristine on ER1.**

Architecture: one scan → node tree → dual mapper. Locals: `lcl_scanner` → `lcl_parser` → node tree → `lcl_typed_mapper` (DESERIALIZE) / `lcl_gen_mapper` (GENERATE) + `lcl_emitter` (SERIALIZE). Public API mirrors Z_UI2_JSON (static SERIALIZE/DESERIALIZE/GENERATE + _INT + CONSTRUCTOR).

## Features
- Block mappings/sequences (indented + flush-style), plain/single/double quoted scalars, flow collections `{}`/`[]`
- Block scalars `|`/`>` with chomping + folding
- Anchors/aliases on read (incl. block-header anchors `key: &a |`)
- camelCase/PascalCase inverse key mapping on DESERIALIZE
- Multi-document streams: `GENERATE_ALL` / `DESERIALIZE_ALL`
- CRLF-tolerant, `null`/`Null`/`NULL` recognized, `abap_bool` round-trip

## Performance
Baseline + optimization pass (measured via `Z_UI2_YAML_PERF` at 10k/100k rows). Kept: struct-type descriptor cache in GENERATE (**−23%** at scale). Scanner fast-paths: deserialize −19%, generate −13%. See `docs/yaml.md`.

## Docs
- `docs/yaml.md` — usage reference, limitations, perf baseline
- `docs/feature-requests-yaml.md` — own backlog (declined: anchor emission, tags, `|N` indent)

## Notes
- `history.md` intentionally not touched — that file tracks `/UI2/CL_JSON` (Z_UI2_JSON) releases only.
- Perf harness `Z_UI2_YAML_PERF` requires a one-time class creation on the target system (abapGit pull or SE24) — `SaveClass` cannot create.
- 40 commits, all `z_ui2_yaml`-scoped (branched clean off main; no JSON PATH WIP included).